### PR TITLE
feat(monitoring): fleet observability audit fixes + GPU/tailscale/logs pipeline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ partially applied. Statuses mirror each doc's own `**Status:**` line.
 | [`reference/service-exposure.md`](reference/service-exposure.md) | Discovery exposure audit: what's LAN/tailnet/internet-reachable and why — Docker-published ports bypass the NixOS firewall. Re-audit with `just verify-firewall`. | As-built (2026-07-01) |
 | [`guides/obsidian.md`](guides/obsidian.md) | Obsidian + sync configuration for the desktop hosts. | Guide |
 | [`guides/install.md`](guides/install.md) | Host bootstrap walkthrough (nixos-anywhere / ISO paths). | Guide |
+| [`guides/yazi.md`](guides/yazi.md) | Yazi file manager for GUI users: GUI→yazi keymap bridge, cheatsheet popup, Nautilus fallback. | Guide |
 
 ## Designs and proposals
 

--- a/docs/guides/yazi.md
+++ b/docs/guides/yazi.md
@@ -1,0 +1,66 @@
+# Yazi — the file manager, for GUI refugees
+
+**Status:** Guide
+
+Yazi is the primary file manager on the desktop hosts (Hyprland). It runs in a
+terminal but behaves like a GUI file manager once your fingers adjust — this
+page is the bridge. Nautilus stays installed as a mouse-driven **plan B**.
+
+Config lives in `modules/terminal/yazi.nix` (fleet-wide base) and
+`modules/desktop/yazi-desktop.nix` (desktop-only: theme, plugins, GUI keymaps,
+the cheatsheet popup). Both are additive — the GUI keys below coexist with
+yazi's native `hjkl`/`y`/`x`/`p`, so you can graduate off the training wheels
+without relearning anything.
+
+## Open it
+
+| Shortcut | Opens |
+|----------|-------|
+| `SUPER + E` | **yazi** (in ghostty) — the default |
+| double-click a folder | yazi (via mime handler) |
+| `SUPER + SHIFT + E` | **Nautilus** — the GUI fallback when you're stuck |
+| `SUPER + /` | **Cheatsheet popup** (rofi) — the same table as below |
+
+Inside yazi, `~` opens yazi's own complete keymap reference.
+
+## GUI habit → yazi key
+
+Everything a nautilus user reaches for, mapped 1:1:
+
+| Your GUI reflex | yazi key | Native yazi equivalent |
+|-----------------|----------|------------------------|
+| Copy | `Ctrl+C` | `y` |
+| Cut | `Ctrl+X` | `x` |
+| Paste | `Ctrl+V` | `p` (`P` = overwrite) |
+| Delete → trash | `Delete` | `d` (`Shift+D` = delete forever) |
+| Rename | `F2` | `r` |
+| Up / back a folder | `Backspace` or `←` | `h` |
+| Open file / enter folder | `Enter` or `→` | `l` |
+| First / last item | `Home` / `End` | `gg` / `G` |
+| Select multiple | `Space` | `Space`, or `v` for visual range |
+| Mouse | double-click opens, scroll scrolls | (on by default) |
+
+There is no `F5` — yazi watches the directory and refreshes itself.
+
+## Power moves (the reason yazi beats a GUI)
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+D` | Drag the selection into any GUI app (ripdrag) |
+| `Ctrl+T` | Open a terminal in the current folder |
+| `Ctrl+E` | Extract archive(s) here (ouch) |
+| `m` / `'` | Save / jump to a bookmark |
+| `M` | Mount / unmount a USB drive |
+| `c m` | chmod the selection |
+| `/` | Filter/search (`n` / `N` = next / prev) |
+| `.` | Toggle hidden files |
+
+Archives preview inline (peek inside without extracting); git status shows as a
+column in any repo. Theme is Tokyonight, matching the rest of the desktop.
+
+## Stuck?
+
+`SUPER + SHIFT + E` gives you Nautilus — full mouse GUI, drag-drop, upload
+dialogs. It's configured too: right-click → **Open in Terminal** launches
+ghostty, and it uses the Tokyonight GTK theme. Use it whenever the TUI fights
+you; there's no penalty for bailing.

--- a/docs/proposals/2026-06-29-grafana-fleet-monitoring.md
+++ b/docs/proposals/2026-06-29-grafana-fleet-monitoring.md
@@ -1,7 +1,11 @@
 # Fleet observability — complete the Grafana monitoring stack
 
 **Status:** In progress — forks decided + Phase 1 implemented 2026-07-01 (see
-below); Phase 2 blocked on the cadvisor name-metric gap, Phase 3 not started.
+below); Phase 2 blocked on the cadvisor name-metric gap. Phase 3 metrics are
+**half-live** (audit 2026-07-02): kube-state-metrics + kubelet cAdvisor flow
+into the discovery Prometheus via homelab-gitops `alloy-metrics` (`b0773ea`);
+control-plane scrape, traefik metrics, and all k8s alert rules still missing.
+See "Audit findings (2026-07-02)" below.
 **Date:** 2026-06-29
 **Audience:** Maintainers of `desktop-nixos` + `servarr`
 
@@ -68,17 +72,61 @@ host metrics→Prometheus, etcd metrics→`/bulk`. In-cluster workload/control-p
 metrics (kube-state-metrics, kubelet cAdvisor, apiserver/scheduler/cm) are the
 suspected gap — the dashboard exists but may be partially unfed.
 
-### Coverage matrix (fill during Phase 0 audit)
+### Coverage matrix (audited 2026-07-02, live Prometheus queries)
 
 | Host | Host metrics | Container metrics | Logs | Alerts today |
 |------|:---:|:---:|:---:|---|
-| discovery | ✅ unix | ✅ cadvisor | ✅ | disk, backup |
-| kepler | ✅ unix | ❓ cadvisor? | ✅ | — |
-| orion | ✅ unix | ❓ cadvisor? | ✅ | — |
-| pathfinder | ✅ unix | n/a | ✅ | — |
-| laptop | ✅ unix | n/a | ✅ | — |
-| archinaut (RPi3) | ❓ (low-mem) | n/a | ❓ | — |
-| k3s cluster | partial (nodes/etcd) | ❓ kubelet | ✅ | — |
+| discovery | ✅ unix | ✅ cadvisor (no `name` label) | ✅ | host-health, disk, backup, openbao |
+| kepler | ✅ unix | ✅ cadvisor (no `name` label) | ✅ | host-health group (fleet-wide) |
+| orion | ⚠️ `up==0` (see audit) | ✅ cadvisor (no `name` label) | ✅ | host-health group (fleet-wide) |
+| pathfinder | ❌ absent ≥7d (see audit) | n/a | ❓ | host-health group (fleet-wide) |
+| laptop | ✅ unix | n/a | ✅ | host-health group (fleet-wide) |
+| archinaut (RPi3) | ❌ deliberate (alloy omitted, ~260 MB RSS) | n/a | ❌ | — |
+| voyager | ✅ node-exporter scrape | n/a | n/a | scrape-down, disk, restic-check |
+| k3s cluster | ✅ KSM (3.7k series) + kubelet cAdvisor pods | ❌ control-plane, ❌ traefik | ✅ | — |
+
+### Audit findings (2026-07-02)
+
+Live issues found while auditing the matrix:
+
+1. **orion `up{job="integrations/unix"} == 0`** — host is up (its servarr
+   Alloy pushes cadvisor fine) but the NixOS fleet Alloy's unix-exporter
+   scrape fails. `host-alloy-down` should be firing; investigate + fix.
+2. **Absent-host hole.** pathfinder has emitted nothing for ≥7 days and no
+   alert fired: `host-alloy-down` matches `up == 0`, but a host that vanishes
+   from the vector produces no series (and no NoData while other hosts keep
+   the query non-empty). The "or series `absent` per host" bullet in section A
+   was never implemented. Fix: per-host `absent_over_time()` rules for
+   **always-on** hosts only (kepler, orion — voyager already covered;
+   pathfinder/laptop are workstations that legitimately power off; discovery
+   monitoring itself is the accepted SPOF).
+3. **remote_write lag ~5–15 min** observed (instant queries empty while
+   `-10m` evaluations return data). Alert `for:` + relative windows must
+   tolerate this; prefer ≥15 m lookbacks for push-fed rules.
+4. **Traefik "gap" is not a bug** (diagnosed 2026-07-02): the scrape is fully
+   healthy (`up{job="traefik"} == 1` continuously, 21.7k samples/14d). Traefik
+   registers `traefik_entrypoint_requests_total` & co. **lazily per label
+   combination** and they reset on pod restart — the lab ingresses have simply
+   had zero traffic since the c91172d validation curls (2026-06-21). Use
+   `... or vector(0)` in panels; alert on `up{job="traefik"}`, never on
+   request-counter presence. Optional: a periodic probe against a lab ingress
+   keeps the series registered and validates LB→NodePort→router end-to-end.
+5. **k3s pods restart every few hours-days** (exit 255, reason Unknown; 16–32
+   restarts/12d fleet-wide in the cluster) — the microvm nodes themselves
+   appear to reboot. Not what suppressed the traefik counters, but worth a
+   separate investigation.
+6. **archinaut** — Alloy intentionally omitted
+   (`modules/hosts/archinaut/default.nix`); section A's "lightweight external
+   check" remains undecided/unbuilt.
+7. **orion root cause** (diagnosed 2026-07-02): amdgpu **SMU firmware hang**
+   (since 19:43 same day, after the 19:21 reboot) wedges node_exporter's hwmon
+   collector in an uninterruptible sysfs read → `/metrics` never returns →
+   `up==0`; cadvisor in the same Alloy process is unaffected. Unrecoverable
+   from userspace (D-state victims incl. a stuck torch CUDA check) — needs a
+   reboot, which folds into the pending b3daafc deploy-rs-boot window.
+   Hardening option: exclude the hwmon collector on GPU hosts in
+   `modules/services/alloy.nix` so a firmware wedge degrades one collector
+   instead of killing all host metrics.
 
 ## Goals
 
@@ -120,10 +168,12 @@ Metrics exist; **alert rules don't**. Add (PromQL → Grafana rules → Discord)
 - **Decided (2026-07-01) — metrics path: (b) Alloy in-cluster** scraping
   cluster components → `remote_write` to the discovery Prometheus (matches the
   existing push pattern; single Prometheus, single Grafana).
-- Components to scrape: **kube-state-metrics** (workload health — the big gap),
-  kubelet **cAdvisor** (pod/container metrics), node-exporter DaemonSet,
-  control-plane (apiserver/scheduler/controller-manager), **etcd** (partly
-  done), ingress controller, CSI/NFS.
+  **Implemented 2026-07-02-ish** in homelab-gitops (`platform/alloy-metrics`,
+  `platform/kube-state-metrics`, commits `b0773ea`/`c91172d`) — KSM + kubelet
+  cAdvisor verified flowing into the discovery Prometheus.
+- Still to scrape: control-plane (apiserver/scheduler/controller-manager —
+  `apiserver_request_total` absent), kubelet's own metrics (`kubelet_*`
+  absent), ingress controller (traefik broken, see audit), CSI/NFS.
 - Alerts: node `NotReady`, pod `CrashLoopBackOff`, deployment replicas
   unavailable, PVC `Pending`, job/cronjob failed, etcd unhealthy, cert expiry,
   control-plane down. (kube-prometheus ships a vetted rule set — port the subset

--- a/modules/desktop/hyprland.nix
+++ b/modules/desktop/hyprland.nix
@@ -87,7 +87,8 @@
 
         settings = {
           terminal = {_var = "ghostty";};
-          fileManager = {_var = "nautilus --new-window";};
+          fileManager = {_var = "ghostty -e yazi";};
+          fileManagerGui = {_var = "nautilus --new-window";};
           browser = {_var = "brave";};
           teamsApp = {_var = "brave --user-data-dir=$HOME/.local/share/brave-webapps/teams --no-first-run --no-default-browser-check --app=https://teams.microsoft.com/v2/";};
           whatsappApp = {_var = "brave --user-data-dir=$HOME/.local/share/brave-webapps/whatsapp --no-first-run --no-default-browser-check --app=https://web.whatsapp.com/";};
@@ -347,6 +348,8 @@
               {_args = ["SUPER + N" (mkLuaInline ''hl.dsp.exec_cmd(terminal .. " -e nvim")'')];}
               {_args = ["SUPER + T" (mkLuaInline "hl.dsp.exec_cmd(terminal)")];}
               {_args = ["SUPER + E" (mkLuaInline "hl.dsp.exec_cmd(fileManager)")];}
+              {_args = ["SUPER + SHIFT + E" (mkLuaInline "hl.dsp.exec_cmd(fileManagerGui)")];}
+              {_args = ["SUPER + slash" (mkLuaInline ''hl.dsp.exec_cmd("yazi-help")'')];}
               {_args = ["SUPER + D" (mkLuaInline ''hl.dsp.exec_cmd("pkill rofi || rofi -show drun")'')];}
               {_args = ["SUPER + W" (mkLuaInline "hl.dsp.window.close()")];}
               {_args = ["SUPER + Backspace" (mkLuaInline "hl.dsp.window.close()")];}

--- a/modules/desktop/theming.nix
+++ b/modules/desktop/theming.nix
@@ -12,6 +12,22 @@
         gtk-theme = "Tokyonight-Dark";
         icon-theme = "Papirus-Dark";
       };
+      # Nautilus (plan-B GUI file manager): right-click "Open in Terminal" → ghostty.
+      "com/github/stunkymonkey/nautilus-open-any-terminal" = {
+        terminal = "ghostty";
+        new-tab = false;
+        flatpak = "off";
+      };
+      "org/gnome/nautilus/preferences" = {
+        default-folder-viewer = "list-view";
+        show-hidden-files = true;
+        show-delete-permanently = true;
+        click-policy = "double";
+      };
+      "org/gtk/gtk4/settings/file-chooser" = {
+        sort-directories-first = true;
+        show-hidden = true;
+      };
     };
     gtk = {
       enable = true;

--- a/modules/desktop/yazi-desktop.nix
+++ b/modules/desktop/yazi-desktop.nix
@@ -1,13 +1,64 @@
 _: {
   # Desktop-only yazi extras. Base yazi (profile-base, fleet-wide incl. servers)
-  # stays a lean TUI; these bits pull GUI deps (ripdrag/GTK4) + ghostty, so they
-  # live here and load only via profile-desktop.
-  flake.modules.home.yazi-desktop = {pkgs, ...}: {
-    # ripdrag: the drag plugin shells out to it (Wayland-native drag source).
-    home.packages = [pkgs.ripdrag];
-
+  # stays a lean TUI; these bits pull GUI deps (ripdrag/GTK4), ghostty, and extra
+  # binaries (ouch), so they live here and load only via profile-desktop.
+  flake.modules.home.yazi-desktop = {pkgs, ...}: let
+    # Tier 2 discoverability: GUI→yazi cheatsheet popup on SUPER+/ (themed rofi).
+    yaziCheatsheet = pkgs.writeText "yazi-cheatsheet.txt" ''
+      Ctrl+C          Copy file(s)
+      Ctrl+X          Cut file(s)
+      Ctrl+V          Paste
+      Delete          Move to trash          (Shift+D = delete forever)
+      F2              Rename
+      Backspace / ←   Up to parent folder
+      Enter / →       Open file / enter folder
+      Home / End      First / last item
+      Space           Select (multi-select)
+      Ctrl+C…Ctrl+V   Copy/paste also work the yazi way: y / x / p
+      Ctrl+D          Drag selection into a GUI app
+      Ctrl+T          Open a terminal in this folder
+      Ctrl+E          Extract archive here
+      m  /  '         Save / jump to bookmark
+      M               Mount / unmount USB drive
+      c m             chmod
+      /               Search        (n / N = next / prev match)
+      .               Toggle hidden files
+      ~               Yazi's own full keymap help
+      q               Quit yazi      (Super+Shift+E opens Nautilus instead)
+    '';
+    yaziHelp = pkgs.writeShellScriptBin "yazi-help" ''
+      exec ${pkgs.rofi}/bin/rofi -dmenu -i -p "yazi" \
+        -mesg "GUI → yazi cheatsheet — Esc to close" < ${yaziCheatsheet}
+    '';
+  in {
+    home.packages = [yaziHelp];
     programs.yazi = {
-      plugins.drag = pkgs.yaziPlugins.drag;
+      # Put helper binaries on yazi's own PATH (not the whole session).
+      # wl-clipboard = wl-copy, needed for yazi's `c` copy-to-clipboard menu on Wayland.
+      extraPackages = [pkgs.ripdrag pkgs.ouch pkgs.wl-clipboard];
+
+      plugins = {
+        # setup = true → HM emits require("<name>"):setup(settings) in init.lua.
+        git = {
+          package = pkgs.yaziPlugins.git;
+          setup = true;
+          settings.order = 1500;
+        };
+        bookmarks = {
+          package = pkgs.yaziPlugins.bookmarks;
+          setup = true;
+        };
+        full-border = {
+          package = pkgs.yaziPlugins.full-border;
+          setup = true;
+        };
+        # Keymap-only plugins — no setup() call needed.
+        drag = pkgs.yaziPlugins.drag;
+        smart-enter = pkgs.yaziPlugins.smart-enter;
+        mount = pkgs.yaziPlugins.mount;
+        chmod = pkgs.yaziPlugins.chmod;
+        ouch = pkgs.yaziPlugins.ouch;
+      };
 
       flavors."tokyo-night" = pkgs.fetchFromGitHub {
         owner = "BennyOe";
@@ -20,6 +71,29 @@ _: {
         light = "tokyo-night";
       };
 
+      settings.plugin = {
+        # git status as linemode column (id field dropped: yazi > v26.1.22).
+        prepend_fetchers = [
+          {
+            url = "*";
+            run = "git";
+            group = "git";
+          }
+          {
+            url = "*/";
+            run = "git";
+            group = "git";
+          }
+        ];
+        # Peek inside archives without extracting.
+        prepend_previewers = [
+          {
+            mime = "application/{*zip,tar,bzip2,7z*,rar,xz,zstd,java-archive}";
+            run = "ouch";
+          }
+        ];
+      };
+
       keymap.mgr.prepend_keymap = [
         {
           on = ["<C-d>"];
@@ -30,6 +104,94 @@ _: {
           on = ["<C-t>"];
           run = "shell 'ghostty' --orphan";
           desc = "Open a terminal in the current folder";
+        }
+        {
+          on = ["<C-e>"];
+          run = ''shell 'ouch d -y "$@"' --confirm'';
+          desc = "Extract archive(s) here (ouch)";
+        }
+        {
+          on = ["l"];
+          run = "plugin smart-enter";
+          desc = "Enter dir or open file";
+        }
+        {
+          on = ["m"];
+          run = "plugin bookmarks save";
+          desc = "Save bookmark";
+        }
+        {
+          on = ["'"];
+          run = "plugin bookmarks jump";
+          desc = "Jump to bookmark";
+        }
+        {
+          on = ["b" "d"];
+          run = "plugin bookmarks delete";
+          desc = "Delete bookmark";
+        }
+        {
+          on = ["b" "D"];
+          run = "plugin bookmarks delete_all";
+          desc = "Delete all bookmarks";
+        }
+        {
+          on = ["M"];
+          run = "plugin mount";
+          desc = "Mount manager (USB drives)";
+        }
+        {
+          on = ["c" "m"];
+          run = "plugin chmod";
+          desc = "chmod selection";
+        }
+
+        # --- Tier 1: GUI muscle-memory bridge (additive — yazi natives y/x/p/d/r
+        # still work; these just add the keys a nautilus user's fingers expect). ---
+        {
+          on = ["<C-c>"];
+          run = "yank";
+          desc = "Copy file(s) [GUI Ctrl+C]";
+        }
+        {
+          on = ["<C-x>"];
+          run = "yank --cut";
+          desc = "Cut file(s) [GUI Ctrl+X]";
+        }
+        {
+          on = ["<C-v>"];
+          run = "paste";
+          desc = "Paste [GUI Ctrl+V]";
+        }
+        {
+          on = ["<Delete>"];
+          run = "remove";
+          desc = "Move to trash [GUI Delete]";
+        }
+        {
+          on = ["<F2>"];
+          run = "rename --cursor=before_ext";
+          desc = "Rename [GUI F2]";
+        }
+        {
+          on = ["<Backspace>"];
+          run = "leave";
+          desc = "Up to parent folder [GUI Backspace]";
+        }
+        {
+          on = ["<Enter>"];
+          run = "plugin smart-enter";
+          desc = "Open file / enter folder [GUI Enter]";
+        }
+        {
+          on = ["<Home>"];
+          run = "arrow top";
+          desc = "First item [GUI Home]";
+        }
+        {
+          on = ["<End>"];
+          run = "arrow bot";
+          desc = "Last item [GUI End]";
         }
       ];
     };

--- a/modules/packages/desktop.nix
+++ b/modules/packages/desktop.nix
@@ -33,6 +33,8 @@ _: {
       ghostty
       libnotify
       nautilus
+      nautilus-python # loads nautilus-open-any-terminal extension
+      nautilus-open-any-terminal # right-click "Open in Terminal" → ghostty
       blueman
       clipse
       cliphist

--- a/modules/profiles/desktop.nix
+++ b/modules/profiles/desktop.nix
@@ -43,6 +43,7 @@ in {
       m.home.rofi
       m.home.wlogout
       m.home.mime
+      m.home.yazi-desktop
       m.home.fonts
       m.home.theming
       m.home.clipboard

--- a/modules/services/alloy.nix
+++ b/modules/services/alloy.nix
@@ -80,6 +80,22 @@ _: {
       }
 
       // ============================================================================
+      // Tailscale client metrics — tailscaled serves Prometheus metrics on the
+      // magic IP (local-only, no auth, GA since 1.78). Differentiated value over
+      // node_network{device="tailscale0"}: direct-vs-DERP path split on
+      // tailscaled_{inbound,outbound}_bytes_total and tailscaled_health_messages.
+      // ============================================================================
+      prometheus.scrape "tailscale" {
+        targets = [{
+          __address__ = "100.100.100.100:80",
+          instance    = sys.env("HOSTNAME"),
+        }]
+        metrics_path    = "/metrics"
+        forward_to      = [prometheus.remote_write.prometheus.receiver]
+        scrape_interval = "60s"
+      }
+
+      // ============================================================================
       // Prometheus remote write -> Discovery Prometheus (via Tailscale).
       // :9090/api/v1/write, --web.enable-remote-write-receiver enabled on the
       // Prometheus container (servarr discovery/monitoring.yml). The old :9009

--- a/modules/services/alloy.nix
+++ b/modules/services/alloy.nix
@@ -50,6 +50,15 @@ _: {
         textfile {
           directory = "/var/lib/node-exporter-textfile"
         }
+        // An amdgpu SMU firmware hang leaves hwmon sysfs reads blocked in
+        // uninterruptible D-state; NodeCollector.Collect waits on every
+        // collector, so one wedged read killed ALL host metrics on orion
+        // (2026-07-02, up==0 while the host was fine). Excluding the amdgpu
+        // chip caps the blast radius to GPU temps; CPU/board sensors still
+        // report. No-op on hosts without an AMD GPU.
+        hwmon {
+          chip_exclude = "amdgpu"
+        }
       }
 
       prometheus.scrape "host_metrics" {

--- a/modules/services/alloy.nix
+++ b/modules/services/alloy.nix
@@ -1,5 +1,5 @@
 _: {
-  flake.modules.nixos.alloy = _: {
+  flake.modules.nixos.alloy = {config, ...}: {
     services.alloy = {
       enable = true;
       # Bind the Alloy HTTP UI/API to localhost only — it contains pipeline
@@ -32,7 +32,11 @@ _: {
       // ============================================================================
       loki.source.journal "journal" {
         forward_to = [loki.write.loki.receiver]
-        labels     = { "source" = "journal", "host" = sys.env("HOSTNAME") }
+        // Hostname is baked in at build time: sys.env("HOSTNAME") is unset in
+        // the systemd unit environment, which left the host label EMPTY on all
+        // fleet hosts (found 2026-07-03 building the Logs dashboard — journal
+        // was one unlabeled fleet-wide stream).
+        labels     = { "source" = "journal", "host" = "${config.networking.hostName}" }
       }
 
       loki.write "loki" {
@@ -93,7 +97,9 @@ _: {
       prometheus.scrape "tailscale" {
         targets = [{
           __address__ = "100.100.100.100:80",
-          instance    = sys.env("HOSTNAME"),
+          // Build-time hostname — sys.env("HOSTNAME") is empty in the unit env
+          // (same bug as the journal host label above).
+          instance    = "${config.networking.hostName}",
         }]
         metrics_path    = "/metrics"
         forward_to      = [prometheus.remote_write.prometheus.receiver]

--- a/modules/services/alloy.nix
+++ b/modules/services/alloy.nix
@@ -59,6 +59,11 @@ _: {
         hwmon {
           chip_exclude = "amdgpu"
         }
+        // AMD GPU busy % + VRAM (node_drm_gpu_busy_percent,
+        // node_drm_memory_vram_*) from /sys/class/drm. No-op on hosts without
+        // DRM devices; GPU temps stay excluded via the amdgpu chip_exclude
+        // above.
+        enable_collectors = ["drm"]
       }
 
       prometheus.scrape "host_metrics" {


### PR DESCRIPTION
Audit-driven fixes from the 2026-07-02/03 fleet-monitoring work:

- docs: record the live audit findings in the grafana-fleet-monitoring RFC
- alloy: exclude amdgpu hwmon chip (SMU-hang wedge killed all host metrics on orion)
- alloy: scrape tailscaled client metrics fleet-wide (direct-vs-DERP split)
- alloy: enable drm collector (AMD GPU busy/VRAM for orion)
- alloy: fix empty journal host label + tailscale instance label (sys.env unset in unit env — baked config.networking.hostName instead)

Validated: alloy fmt+validate on rendered orion config, lint/fmt-check, orion dry-build.