### PR TITLE
fix(justfile): advertise i686-linux on the orion builder

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ ip_voyager := `jq -r '.hosts.voyager.ip' fleet.json`
 ip_telstar := `jq -r '.hosts.telstar.ip' fleet.json`
 
 # Build offload to orion (Ryzen 9 5950X) via ssh-ng
-orion_builder := "ssh-ng://erik@" + ip_orion + " x86_64-linux,aarch64-linux /root/.ssh/nix-builder 16 2 big-parallel,benchmark,kvm,nixos-test"
+orion_builder := "ssh-ng://erik@" + ip_orion + " i686-linux,x86_64-linux,aarch64-linux /root/.ssh/nix-builder 16 2 big-parallel,benchmark,kvm,nixos-test"
 
 default:
     @just --list


### PR DESCRIPTION
kepler's closure carries 32-bit graphics (nvidia EGL x32); with --max-jobs 0 and a builder advertising only x86_64/aarch64, the i686 drv strands deploy-rs ('Failed to find a machine for remote build') — hit live on the 2026-07-03 kepler boot-stage. x86_64 hosts build i686 natively; advertising it costs nothing.