### PR TITLE
perf(alloy): keep-filter the tailscale scrape

### DIFF
--- a/modules/services/alloy.nix
+++ b/modules/services/alloy.nix
@@ -102,8 +102,21 @@ _: {
           instance    = "${config.networking.hostName}",
         }]
         metrics_path    = "/metrics"
-        forward_to      = [prometheus.remote_write.prometheus.receiver]
+        forward_to      = [prometheus.relabel.tailscale_keep.receiver]
         scrape_interval = "60s"
+      }
+
+      // Keep only the differentiated series named above — the rest of the
+      // endpoint duplicates node_network or is static gauges, ~40-60
+      // series/host across the fleet for nothing (mirrors the keep-stage
+      // discipline of the homelab-gitops in-cluster Alloy).
+      prometheus.relabel "tailscale_keep" {
+        rule {
+          source_labels = ["__name__"]
+          regex         = "tailscaled_(inbound|outbound)_(bytes|packets)_total|tailscaled_health_messages"
+          action        = "keep"
+        }
+        forward_to = [prometheus.remote_write.prometheus.receiver]
       }
 
       // ============================================================================


### PR DESCRIPTION
From the /simplify efficiency pass: the tailscale scrape shipped the full tailscaled endpoint (~40-60 series/host fleet-wide) where only the direct-vs-DERP byte/packet split + health messages are differentiated — the rest duplicates node_network. Adds a keep-stage relabel mirroring the gitops in-cluster Alloy discipline. alloy validate on rendered orion config passes. Hosts pick it up on their next (daily auto-)switch.