### PR TITLE
feat(discovery): expose OpenBao to isolated SWAG bridge

### DIFF
--- a/docs/reference/service-exposure.md
+++ b/docs/reference/service-exposure.md
@@ -39,7 +39,7 @@ it is unreachable from the network.
 
 | Port | Bound to | Service | Notes |
 |---|---|---|---|
-| 8200 | 127.0.0.1 + tailnet IP + `172.31.82.1` | OpenBao (`bao`) | tailnet listener allowlisted on `tailscale0`; SWAG listener restricted to dedicated `br-openbao-proxy` bridge |
+| 8200 | 127.0.0.1 + tailnet IP + `172.31.82.1` | OpenBao (`bao`) | tailnet listener allowlisted on `tailscale0`; SWAG listener restricted to dedicated `br-openbao` bridge |
 | 8384 | 127.0.0.1 | syncthing GUI | |
 | 8888 | 127.0.0.1 | atuin-server | |
 | 12345 | 127.0.0.1 | alloy | |

--- a/docs/reference/service-exposure.md
+++ b/docs/reference/service-exposure.md
@@ -39,7 +39,7 @@ it is unreachable from the network.
 
 | Port | Bound to | Service | Notes |
 |---|---|---|---|
-| 8200 | 127.0.0.1 + tailnet IP | OpenBao (`bao`) | tailnet listener allowlisted on `tailscale0` only |
+| 8200 | 127.0.0.1 + tailnet IP + `172.31.82.1` | OpenBao (`bao`) | tailnet listener allowlisted on `tailscale0`; SWAG listener restricted to dedicated `br-openbao-proxy` bridge |
 | 8384 | 127.0.0.1 | syncthing GUI | |
 | 8888 | 127.0.0.1 | atuin-server | |
 | 12345 | 127.0.0.1 | alloy | |

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -68,7 +68,7 @@
     # discovery-networking stays default-closed (8200 not in allowedTCPPorts),
     # so the store is unreachable from the LAN/eno1/br0.
     networking.firewall.interfaces.tailscale0.allowedTCPPorts = [8200];
-    networking.firewall.interfaces.br-openbao-proxy.allowedTCPPorts = [8200];
+    networking.firewall.interfaces.br-openbao.allowedTCPPorts = [8200];
 
     # The tailnet and SWAG listeners bind addresses created by tailscaled and
     # Docker. A cold boot can race either interface, so retry without a

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -47,6 +47,14 @@
           address = "100.76.140.121:8200";
           tls_disable = true;
         };
+        # SWAG reaches the UI/API through a dedicated internal Docker bridge.
+        # Only SWAG joins this network; the listener is not exposed to the LAN
+        # or the general homelab container network.
+        listener.swag_proxy = {
+          type = "tcp";
+          address = "172.31.82.1:8200";
+          tls_disable = true;
+        };
         storage.raft = {
           path = "/var/lib/openbao";
           node_id = "discovery";
@@ -60,12 +68,11 @@
     # discovery-networking stays default-closed (8200 not in allowedTCPPorts),
     # so the store is unreachable from the LAN/eno1/br0.
     networking.firewall.interfaces.tailscale0.allowedTCPPorts = [8200];
+    networking.firewall.interfaces.br-openbao-proxy.allowedTCPPorts = [8200];
 
-    # The tailnet listener binds 100.76.140.121, which only exists once tailscaled
-    # has brought the interface up. openbao starts after network.target, so a cold
-    # boot can race the IP and the bind fails. Order after tailscaled and retry
-    # without a start-limit cap so the unit self-heals once the IP appears
-    # (rather than tripping the default 5-in-10s limit and staying dead).
+    # The tailnet and SWAG listeners bind addresses created by tailscaled and
+    # Docker. A cold boot can race either interface, so retry without a
+    # start-limit cap until both exist.
     systemd.services.openbao = {
       after = ["tailscaled.service" "network-online.target"];
       wants = ["network-online.target"];


### PR DESCRIPTION
## Summary
- add the host OpenBao listener on the isolated SWAG bridge
- restrict port 8200 to the dedicated bridge interface
- document the exposure boundary

## Verification
- docs-check, lint, fmt-check passed
- `just dry discovery` passed
- `just switch-discovery` activated and confirmed
- OpenBao initialized, unsealed, raft healthy
- loopback, tailnet, and isolated bridge listeners present
- SWAG/UI/API/DNS smoke passed

Merge after ErikBPF/servarr PR.