### PR TITLE
ci: harden GitHub workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -12,10 +15,11 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/nix-installer-action@e50d5f73bfe71c2dd0aa4218de8f4afa59f8f81d # v16
 
       - name: Lint
         run: nix develop -c just lint
@@ -25,14 +29,15 @@ jobs:
 
   eval:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         host: [pathfinder, laptop, orion, discovery, kepler]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/nix-installer-action@e50d5f73bfe71c2dd0aa4218de8f4afa59f8f81d # v16
 
       - name: Evaluate ${{ matrix.host }}
         run: nix eval .#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel.drvPath
@@ -41,9 +46,10 @@ jobs:
   # + autoUpgrade, so this guards against the lock silently drifting too far.
   flake-lock:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/flake-checker-action@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: DeterminateSystems/flake-checker-action@de924abd783455e8429c858962b9e43062d19da1 # main
 
   # Boot the k3s test cluster (1 server + 1 agent) in QEMU, fully offline, and
   # assert it forms — catches k3s node-config regressions before they hit kepler.
@@ -53,12 +59,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Free disk space (airgap bundle is large)
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
             /usr/local/share/boost /opt/hostedtoolcache
           sudo docker image prune -af || true
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/nix-installer-action@e50d5f73bfe71c2dd0aa4218de8f4afa59f8f81d # v16
       - name: k3s smoke test
         run: nix build .#checks.x86_64-linux.k3s-smoke -L

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>ErikBPF/renovate-config"],
+  "enabledManagers": ["github-actions", "nix"],
+  "packageRules": [
+    {
+      "description": "Keep GitHub Actions pinned to immutable commits",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- restrict workflow token to read-only contents
- pin all third-party Actions to immutable commits
- add job timeouts and Renovate coverage for Actions/Nix

## Verification
- `just lint`
- `just fmt-check`