### PR TITLE
fix(endeavour): provide watchdog netstat

### DIFF
--- a/modules/hosts/endeavour/ampagent.nix
+++ b/modules/hosts/endeavour/ampagent.nix
@@ -134,6 +134,7 @@
       description = "Quest KACE AMP WatchDog";
       after = ["ampagent.service"];
       wants = ["ampagent.service"];
+      path = [pkgs.nettools];
 
       serviceConfig = {
         Type = "oneshot";


### PR DESCRIPTION
Add nettools to AMPWatchDog service PATH. The vendor watchdog conditionally invokes legacy netstat; without it, later timer runs exit 255 even after the KACE path symlink is fixed.