### PR TITLE
feat(ai): deploy HA harness runtime

### DIFF
--- a/justfile
+++ b/justfile
@@ -2207,6 +2207,13 @@ diagnose-stack target stack:
     IP="$(just _host-ip {{target}})"
     ssh -p 2222 erik@"$IP" 'export XDG_RUNTIME_DIR=/run/user/$(id -u); systemctl --user status podman-compose-{{stack}}.service --no-pager -n30 || true; journalctl --user -u podman-compose-{{stack}}.service --no-pager -n50'
 
+# Re-render static OpenBao templates after a credential rotation.
+refresh-vault-agent target:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP="$(just _host-ip {{target}})"
+    ssh -p 2222 erik@"$IP" 'sudo systemctl restart vault-agent.service; sudo systemctl is-active vault-agent.service'
+
 # Permanently remove the seven disposable AI containers, their seven exact
 # images, and /fast/ai-models. The helper re-inventories and fails closed.
 kepler-retire-ai-serving-user-approved:

--- a/justfile
+++ b/justfile
@@ -2212,7 +2212,7 @@ refresh-vault-agent target:
     #!/usr/bin/env bash
     set -euo pipefail
     IP="$(just _host-ip {{target}})"
-    ssh -p 2222 erik@"$IP" 'sudo systemctl restart vault-agent.service; sudo systemctl is-active vault-agent.service'
+    ssh -p 2222 erik@"$IP" 'sudo systemctl restart vault-agent.service; sudo systemctl is-active vault-agent.service; for _ in $(seq 1 100); do sudo test -s /run/vault-agent/ha-harness.env && break; sleep 0.1; done; sudo test -s /run/vault-agent/ha-harness.env; sudo journalctl -u vault-agent.service --no-pager -n20; sudo awk -F= '"'"'$1 == "LITELLM_API_KEY" {print $2}'"'"' /run/vault-agent/ha-harness.env | sha256sum | sed "s/ .*$/  ha-harness LITELLM_API_KEY/"'
 
 # Permanently remove the seven disposable AI containers, their seven exact
 # images, and /fast/ai-models. The helper re-inventories and fails closed.

--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -15,6 +15,7 @@ _: {
         homepage = ["shared-arr" "shared-grafana"];
         "media-server" = ["media-server" "shared-db"];
         "ai-serving" = ["ai-serving" "shared-db"];
+        "ha-harness" = ["ha-harness"];
         infra = ["shared-db"];
       };
       stacks = [
@@ -29,6 +30,7 @@ _: {
         "homepage" # homepage dashboard
         "tunneling" # cloudflare tunnels
         "ai-serving" # ai inference stack
+        "ha-harness" # HA Qwen tool-caller dry-run; no HA dispatch credential
         "dockhand" # dockhand container updater
         "firmware" # static OTA firmware host (cosmo-notes), LAN-only via SWAG
         "kindle-dash" # e-ink dashboard renderer

--- a/modules/hosts/discovery/networking.nix
+++ b/modules/hosts/discovery/networking.nix
@@ -32,6 +32,7 @@ in {
           53 # DNS
           80 # HTTP
           443 # HTTPS
+          8091 # HA harness dry-run API (bearer-authenticated)
           22000 # syncthing
           32400 # Plex Media Server
         ];

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -257,6 +257,11 @@
             destination = "/run/vault-agent/harbor.env"
             perms = "0400"
           }
+          template {
+            contents = "{{ with secret \"secret/data/home/ha-harness\" }}LITELLM_API_KEY={{ .Data.data.LITELLM_API_KEY }}\nHA_HARNESS_TOKEN={{ .Data.data.HA_HARNESS_TOKEN }}\n{{ end }}"
+            destination = "/run/vault-agent/ha-harness.env"
+            perms = "0444"
+          }
         ''}";
       };
     };

--- a/modules/hosts/kepler/compose.nix
+++ b/modules/hosts/kepler/compose.nix
@@ -14,8 +14,7 @@ _: {
         "infra"
         "whisper-gpu"
         "docs-search"
-        "whisper-gpu"
-        "parakeet-gpu"
+        "qwen4b-gpu"
       ];
     };
   };


### PR DESCRIPTION
Runs Qwen beside Whisper on Kepler and the dry-run HA harness on Discovery, with checked Vault-template refresh operations.\n\nValidated with `just lint`, `just fmt-check`, `just dry discovery`, and `just dry kepler`.