### PR TITLE
feat(ai): verify live HA model route

### DIFF
--- a/justfile
+++ b/justfile
@@ -2207,6 +2207,48 @@ diagnose-stack target stack:
     IP="$(just _host-ip {{target}})"
     ssh -p 2222 erik@"$IP" 'export XDG_RUNTIME_DIR=/run/user/$(id -u); systemctl --user status podman-compose-{{stack}}.service --no-pager -n30 || true; journalctl --user -u podman-compose-{{stack}}.service --no-pager -n50'
 
+# Exercise the deployed HA harness through its Vault-backed LiteLLM route.
+# The request is read-only and the runtime remains dry-run.
+verify-ha-harness-model target="discovery":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP="$(just _host-ip {{target}})"
+    ssh -p 2222 erik@"$IP" 'bash -se' <<'REMOTE'
+    set -euo pipefail
+    set -a
+    source /run/vault-agent/ha-harness.env
+    set +a
+    payload='{
+      "transcript": "qual é o estado da luz da parede do escritório",
+      "room": "escritorio",
+      "area_aliases": ["Escritório"],
+      "manifest_sha256": "285e119ff6eea5713581877cc1a1262cac55923af8727329f42c4f340678fd03",
+      "manifest_source_sha256": "b2461d55a11c6980497019b6914e261480cd346a75440a97b3603e65de633469",
+      "entities": [{
+        "entity_id": "switch.interruptor_escritorio_l2",
+        "display_name": "Parede do escritório",
+        "voice_name": "Parede do escritório",
+        "area_id": "escritorio",
+        "area_name": "Escritório",
+        "domain": "switch",
+        "aliases": ["parede"],
+        "semantic_type": "light_fixture",
+        "operations": ["read_state", "turn_off", "turn_on"],
+        "risk": {"default": "automatic", "operations": {}}
+      }]
+    }'
+    response="$(
+      curl --fail --silent --show-error \
+        -H "Authorization: Bearer $HA_HARNESS_TOKEN" \
+        -H 'Content-Type: application/json' \
+        --data "$payload" \
+        http://127.0.0.1:8091/v1/decide
+    )"
+    jq -e '.decision and (.calls | type == "array") and (.issues | type == "array")' \
+      <<<"$response" >/dev/null
+    jq -c '{decision, calls, issues}' <<<"$response"
+    REMOTE
+
 # Re-render static OpenBao templates after a credential rotation.
 refresh-vault-agent target:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary
- add read-only Vault-backed HA harness model probe
- validate response contract without dispatching actions or exposing credentials

## Verification
- just verify-ha-harness-model discovery
- just lint
- just fmt-check