### PR TITLE
fix(discovery): pin Hermes OCI image

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,17 +449,18 @@
         "nixpkgs": [
           "nixpkgs"
         ],
+        "npm-lockfile-fix": "npm-lockfile-fix",
         "pyproject-build-systems": "pyproject-build-systems",
         "pyproject-nix": "pyproject-nix",
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1783977987,
-        "narHash": "sha256-o7gUI2XTop8dOePJPr3I2qWSCnIBd5vw0bSeWWgP5ho=",
-        "rev": "59586966aadf33086bee3582579cce8984851e82",
-        "revCount": 31,
+        "lastModified": 1784643660,
+        "narHash": "sha256-8UQnub4Hfr+xGObRbjT8eNciTNIDQNDJ/FwLh6armeo=",
+        "rev": "fc44a2da2c6acbe8108b2162f3f51c3e4e66be4f",
+        "revCount": 43,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/ErikBPF/hermes-flake/0.2.31%2Brev-59586966aadf33086bee3582579cce8984851e82/019f5d62-1bc9-7f63-aa4c-221d7d8ffabb/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/ErikBPF/hermes-flake/0.2.43%2Brev-fc44a2da2c6acbe8108b2162f3f51c3e4e66be4f/019f8511-82b4-7772-9e1f-c725782f873a/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -1092,6 +1093,27 @@
       "original": {
         "owner": "nix-community",
         "repo": "nixvim",
+        "type": "github"
+      }
+    },
+    "npm-lockfile-fix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775903712,
+        "narHash": "sha256-2GV79U6iVH4gKAPWYrxUReB0S41ty/Y3dBLquU8AlaA=",
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "rev": "c6093acb0c0548e0f9b8b3d82918823721930fe8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
         "type": "github"
       }
     },

--- a/modules/hosts/discovery/hermes-agents.nix
+++ b/modules/hosts/discovery/hermes-agents.nix
@@ -64,6 +64,17 @@ in {
       inputs.hermes-flake.nixosModules.hermes-agent-oci-argus
     ];
 
+    assertions = [
+      {
+        assertion = builtins.match "^nousresearch/hermes-agent@sha256:[0-9a-f]{64}$" config.services.hermes-agent-oci-daedalus.image != null;
+        message = "Discovery Daedalus Hermes image must use an immutable sha256 digest";
+      }
+      {
+        assertion = builtins.match "^nousresearch/hermes-agent@sha256:[0-9a-f]{64}$" config.services.hermes-agent-oci-argus.image != null;
+        message = "Discovery Argus Hermes image must use an immutable sha256 digest";
+      }
+    ];
+
     sops.secrets."hermes_agents/daedalus_env" = {
       sopsFile = self + "/secrets/sops/secrets.yaml";
       key = "hermes_agents/daedalus_env";
@@ -81,7 +92,7 @@ in {
 
     services.hermes-agent-oci-daedalus = {
       enable = true;
-      image = "nousresearch/hermes-agent:latest";
+      image = "nousresearch/hermes-agent@sha256:229429fe176efa05ca4e542a7e11348482b40c36f903191498c7016f1dfc1019";
       hostDataDir = "/home/${username}/homelab/apps/hermes-daedalus";
       environmentFile = config.sops.secrets."hermes_agents/daedalus_env".path;
       openBindAddress = "0.0.0.0";
@@ -131,7 +142,7 @@ in {
 
     services.hermes-agent-oci-argus = {
       enable = true;
-      image = "nousresearch/hermes-agent:latest";
+      image = "nousresearch/hermes-agent@sha256:229429fe176efa05ca4e542a7e11348482b40c36f903191498c7016f1dfc1019";
       hostDataDir = "/home/${username}/homelab/apps/hermes-argus";
       environmentFile = config.sops.secrets."hermes_agents/argus_env".path;
       openBindAddress = "0.0.0.0";

--- a/modules/hosts/discovery/hermes-oci.nix
+++ b/modules/hosts/discovery/hermes-oci.nix
@@ -39,6 +39,13 @@ in {
   in {
     imports = [inputs.hermes-flake.nixosModules.hermes-agent-oci];
 
+    assertions = [
+      {
+        assertion = builtins.match "^nousresearch/hermes-agent@sha256:[0-9a-f]{64}$" config.services.hermes-agent-oci.image != null;
+        message = "Discovery Hermes image must use an immutable sha256 digest";
+      }
+    ];
+
     # sops dotenv with UPSTREAM-BARE names (no HERMES_ bridge on the OCI path):
     # OPENAI_API_KEY, API_SERVER_KEY, TELEGRAM_BOT_TOKEN, DISCORD_BOT_TOKEN,
     # EXA_API_KEY. Read by the docker daemon (root) at container start.
@@ -61,7 +68,7 @@ in {
       # Keep the container name + ports so SWAG (hermes.* → hermes-agent:8642)
       # and the tailnet/host clients keep working unchanged across the cutover.
       containerName = "hermes-agent";
-      image = "nousresearch/hermes-agent:latest";
+      image = "nousresearch/hermes-agent@sha256:229429fe176efa05ca4e542a7e11348482b40c36f903191498c7016f1dfc1019";
       # Reuse the existing live state dir (restic-backed btrfs subvol):
       # memories, sessions, skills, lazy venv survive the Docker→OCI swap.
       hostDataDir = "/home/${username}/homelab/apps/hermes-agent";


### PR DESCRIPTION
## Summary
- bump `hermes-flake` to `0.2.43` with working OCI healthcheck timers
- pin all three Discovery Hermes containers to immutable upstream digest
- enforce digest pins with Nix assertions

## Verification
- `just lint`
- `just fmt-check`
- `just dry discovery`
- evaluated all three images and healthcheck timers