### PR TITLE
fix(kindle): harden release recovery

### DIFF
--- a/justfile
+++ b/justfile
@@ -4417,7 +4417,7 @@ provision-kindle-release-reporting:
         --arg private_key_b64 "$KINDLE_RELEASE_PRIVATE_KEY_B64" \
         '{data:{app_id:($app_id|tonumber),installation_id:($installation_id|tonumber),private_key_b64:$private_key_b64}}'
     } | base64 -w0)"
-    policy_payload="$(jq -cn --arg policy $'path "secret/data/shared/discord" { capabilities = ["read"] }\npath "secret/data/shared/kindle-release" { capabilities = ["read"] }' '{policy:$policy}' | base64 -w0)"
+    policy_payload="$(jq -cn --arg policy $'path "secret/data/shared/kindle-release" { capabilities = ["read"] }' '{policy:$policy}' | base64 -w0)"
     unset KINDLE_RELEASE_APP_ID KINDLE_RELEASE_INSTALLATION_ID KINDLE_RELEASE_PRIVATE_KEY_B64
     token="$(sops --decrypt --extract '["vault_root_token"]' secrets/sops/secrets.yaml)"
     printf '%s\n%s\n%s\n' "$token" "$policy_payload" "$payload" | ssh -p 2222 erik@{{ip_discovery}} '
@@ -4434,12 +4434,23 @@ provision-kindle-release-reporting:
       printf "%s" "$policy_payload" | base64 --decode > "$body"
       unset policy_payload
       curl --header @"$header" --silent --show-error --fail --request PUT \
-        --data-binary @"$body" http://127.0.0.1:8200/v1/sys/policies/acl/discord-read
+        --data-binary @"$body" http://127.0.0.1:8200/v1/sys/policies/acl/kindle-release-read
+      curl --header @"$header" --silent --show-error --fail \
+        http://127.0.0.1:8200/v1/auth/approle/role/vault-agent > "$body"
+      role_payload="$(jq -c "
+        .data.token_policies
+        | if index(\"kindle-release-read\") then . else . + [\"kindle-release-read\"] end
+        | {token_policies:.}
+      " "$body")"
+      printf "%s" "$role_payload" > "$body"
+      unset role_payload
+      curl --header @"$header" --silent --show-error --fail --request POST \
+        --data-binary @"$body" http://127.0.0.1:8200/v1/auth/approle/role/vault-agent
       printf "%s" "$payload" | base64 --decode > "$body"
       unset payload
       curl --header @"$header" --silent --show-error --fail --request POST \
         --data-binary @"$body" http://127.0.0.1:8200/v1/secret/data/shared/kindle-release
-      echo "kindle_release_reporting=provisioned policy=discord-read"
+      echo "kindle_release_reporting=provisioned policy=kindle-release-read"
     '
 
 diagnose-kindle-claude-usage:

--- a/modules/hosts/discovery/_kindle-release-agent.py
+++ b/modules/hosts/discovery/_kindle-release-agent.py
@@ -679,7 +679,7 @@ def observe_candidate(runner, previous_commit):
         return None
     runner.run(git + ["merge-base", "--is-ancestor", previous_commit, commit])
     changed_paths = runner.run(
-        git + ["diff-tree", "--no-commit-id", "--name-only", "-r", commit]
+        git + ["diff", "--name-only", f"{previous_commit}..{commit}"]
     ).splitlines()
     compose_text = runner.run(git + ["show", f"{commit}:{COMPOSE_PATH}"])
     return validate_candidate(commit, changed_paths, compose_text)
@@ -1349,7 +1349,7 @@ def recover_failed_attempt(state, operations, persist, now, after_revalidate):
         }
     )
     persist(recovered)
-    return poll_release(recovered, operations, persist, now, after_revalidate)
+    return recovered
 
 
 def execute_once():

--- a/tests/kindle-release-agent/test_agent.py
+++ b/tests/kindle-release-agent/test_agent.py
@@ -10,6 +10,7 @@ import json
 import os
 import pathlib
 import stat
+import subprocess
 import tempfile
 import unittest
 from unittest import mock
@@ -18,6 +19,7 @@ from unittest import mock
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 AGENT_PATH = ROOT / "modules/hosts/discovery/_kindle-release-agent.py"
 MODULE_PATH = ROOT / "modules/hosts/discovery/kindle-release-agent.nix"
+JUSTFILE_PATH = ROOT / "justfile"
 
 
 def load_agent():
@@ -1065,11 +1067,9 @@ class ObservationContract(unittest.TestCase):
                 ],
                 [
                     *git,
-                    "diff-tree",
-                    "--no-commit-id",
+                    "diff",
                     "--name-only",
-                    "-r",
-                    self.target,
+                    f"{self.previous}..{self.target}",
                 ],
                 [
                     *git,
@@ -2366,7 +2366,7 @@ class ReleasePollingContract(unittest.TestCase):
         )
         self.assertIs(result, terminal)
 
-    def test_failed_attempt_recovers_previous_baseline_before_retry(self):
+    def test_failed_attempt_quarantines_candidate_until_origin_advances(self):
         failed = self.agent.validate_state(
             dict(
                 self.current,
@@ -2385,9 +2385,7 @@ class ReleasePollingContract(unittest.TestCase):
         )
         operations = mock.Mock()
         persist = mock.Mock()
-        with mock.patch.object(
-            self.agent, "poll_release", return_value=self.current
-        ) as poll:
+        with mock.patch.object(self.agent, "poll_release") as poll:
             result = self.agent.recover_failed_attempt(
                 failed,
                 operations,
@@ -2400,8 +2398,8 @@ class ReleasePollingContract(unittest.TestCase):
         self.assertEqual(recovered["commit"], self.current["commit"])
         self.assertEqual(recovered["phase"], "succeeded")
         self.assertIsNone(recovered["previous"])
-        poll.assert_called_once()
-        self.assertIs(result, self.current)
+        poll.assert_not_called()
+        self.assertEqual(result, recovered)
 
 
 class ReportingOrchestrationContract(unittest.TestCase):
@@ -2897,6 +2895,33 @@ class EntrypointContract(unittest.TestCase):
 
 
 class NixModuleContract(unittest.TestCase):
+    def test_reporting_provision_adds_dedicated_policy_without_replacing_shared(self):
+        source = JUSTFILE_PATH.read_text()
+        recipe = source.split("provision-kindle-release-reporting:", 1)[1].split(
+            "diagnose-kindle-claude-usage:", 1
+        )[0]
+        self.assertIn("sys/policies/acl/kindle-release-read", recipe)
+        self.assertIn("auth/approle/role/vault-agent", recipe)
+        self.assertIn("token_policies", recipe)
+        self.assertNotIn("sys/policies/acl/discord-read", recipe)
+        self.assertNotIn('role_payload="$(jq -c \'', recipe)
+
+    def test_reporting_provision_recipe_has_valid_shell_syntax(self):
+        rendered = subprocess.run(
+            ["just", "--dry-run", "provision-kindle-release-reporting"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        checked = subprocess.run(
+            ["bash", "-n"],
+            input=rendered,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(checked.returncode, 0, checked.stderr)
+
     def test_module_declares_fixed_oneshot_and_disabled_timer(self):
         source = MODULE_PATH.read_text()
         required = (


### PR DESCRIPTION
## Summary

- validate the complete Servarr commit range
- quarantine failed releases after rollback
- attach a dedicated Kindle OpenBao policy without replacing shared access
- add regression coverage for all review findings and recipe quoting

## Verification

- `just test-kindle-release-agent` (93 tests)
- `just lint`
- `just fmt-check`
- `just dry discovery`
- corrected policy provisioned live
- Vault Agent restart rendered every template successfully

Local `nix flake check` intentionally not run per repository policy.