### PR TITLE
fix(discovery): disable Hermes probes

### DIFF
--- a/modules/hosts/discovery/hermes-agents.nix
+++ b/modules/hosts/discovery/hermes-agents.nix
@@ -92,6 +92,7 @@ in {
 
     services.hermes-agent-oci-daedalus = {
       enable = true;
+      enableHealthcheck = false;
       image = "nousresearch/hermes-agent@sha256:229429fe176efa05ca4e542a7e11348482b40c36f903191498c7016f1dfc1019";
       hostDataDir = "/home/${username}/homelab/apps/hermes-daedalus";
       environmentFile = config.sops.secrets."hermes_agents/daedalus_env".path;
@@ -142,6 +143,7 @@ in {
 
     services.hermes-agent-oci-argus = {
       enable = true;
+      enableHealthcheck = false;
       image = "nousresearch/hermes-agent@sha256:229429fe176efa05ca4e542a7e11348482b40c36f903191498c7016f1dfc1019";
       hostDataDir = "/home/${username}/homelab/apps/hermes-argus";
       environmentFile = config.sops.secrets."hermes_agents/argus_env".path;

--- a/modules/hosts/discovery/hermes-oci.nix
+++ b/modules/hosts/discovery/hermes-oci.nix
@@ -64,6 +64,7 @@ in {
 
     services.hermes-agent-oci = {
       enable = true;
+      enableHealthcheck = false;
       backend = "docker";
       # Keep the container name + ports so SWAG (hermes.* → hermes-agent:8642)
       # and the tailnet/host clients keep working unchanged across the cutover.

--- a/tests/hermes-healthchecks/test_disabled.py
+++ b/tests/hermes-healthchecks/test_disabled.py
@@ -1,0 +1,21 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class HermesHealthcheckContract(unittest.TestCase):
+    def test_discovery_disables_all_three_oci_healthchecks(self):
+        primary = (ROOT / "modules/hosts/discovery/hermes-oci.nix").read_text()
+        agents = (ROOT / "modules/hosts/discovery/hermes-agents.nix").read_text()
+
+        self.assertIn("services.hermes-agent-oci = {", primary)
+        self.assertEqual(primary.count("enableHealthcheck = false;"), 1)
+        self.assertIn("services.hermes-agent-oci-daedalus = {", agents)
+        self.assertIn("services.hermes-agent-oci-argus = {", agents)
+        self.assertEqual(agents.count("enableHealthcheck = false;"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- disable primary Hermes healthcheck
- disable Argus and Daedalus healthchecks
- leave all OCI service definitions enabled
- add a three-instance regression contract

## Verification

- `python -m unittest tests/hermes-healthchecks/test_disabled.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`

Local `nix flake check` intentionally not run per repository policy.