### PR TITLE
Restore Bottles and pin rollout authority

### DIFF
--- a/docs/proposals/2026-07-13-stateful-stack-release-hardening-execution-plan.md
+++ b/docs/proposals/2026-07-13-stateful-stack-release-hardening-execution-plan.md
@@ -27,6 +27,11 @@ document must be corrected.
 Leaf repositories land first. Consumers and host orchestration follow only
 after the leaf commit is published and pinned.
 
+Discovery SecretSpec rollout is now tracked independently in Servarr's
+[`machines/discovery/secretspec-inventory.md`](https://github.com/ErikBPF/servarr/blob/d88f5ab11e7723d7ff605f35856819307b245194/machines/discovery/secretspec-inventory.md).
+This execution plan retains K0 and P1 evidence only; its P2–P9 phases do not
+authorize or order additional SecretSpec profiles.
+
 The merged order is `P0 → K0–K5 → P1 → P2 read-only → P3 → P2 mutation → P4–P9`.
 P3 is advanced only as the secondary-DNS safety interlock required by P2; its
 behavior and test contract define the boundary. Kepler and Discovery live mutations

--- a/docs/proposals/2026-07-13-stateful-stack-release-hardening.md
+++ b/docs/proposals/2026-07-13-stateful-stack-release-hardening.md
@@ -10,6 +10,12 @@ preflight, P3 implementation/outage proof, then separately approved P2
 mutation. This proposal remains authoritative for architecture and acceptance
 criteria; the merged execution plan is authoritative for rollout order.
 
+**SecretSpec authority update (2026-07-21):** Discovery SecretSpec scope,
+ordering, and status now live in Servarr's
+[`machines/discovery/secretspec-inventory.md`](https://github.com/ErikBPF/servarr/blob/d88f5ab11e7723d7ff605f35856819307b245194/machines/discovery/secretspec-inventory.md).
+This proposal retains the architecture and historical acceptance evidence; it
+does not define future Discovery SecretSpec profiles.
+
 ## 1. Summary
 
 Make discovery's stateful Compose stacks and the kindle-dash release path safe

--- a/modules/packages/desktop.nix
+++ b/modules/packages/desktop.nix
@@ -1,5 +1,20 @@
 _: {
-  flake.modules.nixos.packages-desktop = {pkgs, ...}: {
+  flake.modules.nixos.packages-desktop = {pkgs, ...}: let
+    bottlesForFusion = pkgs.bottles.override {
+      removeWarningPopup = true;
+      bottles-unwrapped = pkgs.bottles-unwrapped.override {
+        python3Packages = pkgs.python3Packages.overrideScope (
+          _final: prev: {
+            # patool 4.0.5 MIME tests fail with current file/bzip2 output.
+            patool = prev.patool.overrideAttrs {
+              doCheck = false;
+              doInstallCheck = false;
+            };
+          }
+        );
+      };
+    };
+  in {
     # Auto-start Cloudflare WARP daemon (warp-svc.service ships with the package).
     systemd.packages = [pkgs.cloudflare-warp];
     systemd.services.warp-svc.wantedBy = ["multi-user.target"];
@@ -101,6 +116,7 @@ _: {
       # --- CAD / EDA (TPS43 touchpad mount + PCB work) ---
       kicad # EDA suite
       openscad # parametric .scad mounts
+      bottlesForFusion # Wine prefixes for unsupported Windows CAD apps (Fusion 360)
       # freecad — TEMPORARILY REMOVED 2026-07-12: build broken on the current
       # nixpkgs (gdal-minimal/pdal/vtk chain fails). Re-enable once upstream fixes.
       # freecad # gen_step.py STEP export (import FreeCAD, Part)


### PR DESCRIPTION
## Summary
- pin secrets rollout authority in docs
- restore Bottles for the existing Fusion 360 prefix

## Verification
- `just lint`
- `just fmt-check`
- `just dry endeavour`