### PR TITLE
fix(secrets): strengthen DS4 render identity

### DIFF
--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -50,11 +50,15 @@
         "DISCORD_WEBHOOK_INCIDENTS",
         "SCRUTINY_NOTIFY_URLS",
         "WEBHOOK_GRAFANA_ALERTS_SECRET"
-      ]
+      ],
+      "perms": "0444"
     },
     {
       "destination": "/run/vault-agent/tunneling.env",
-      "names": ["CLOUDFLARE_TUNNEL_TOKEN"]
+      "names": [
+        "CLOUDFLARE_TUNNEL_TOKEN"
+      ],
+      "perms": "0444"
     },
     {
       "destination": "/run/vault-agent/monitoring.env",
@@ -65,27 +69,47 @@
         "SCRUTINY_INFLUXDB_PASSWORD",
         "SCRUTINY_INFLUXDB_TOKEN",
         "TELEGRAM_BOT_TOKEN"
-      ]
+      ],
+      "perms": "0444"
     },
     {
       "destination": "/run/vault-agent/shared-db.env",
-      "names": ["POSTGRES_PASSWORD", "REDIS_PASSWORD"]
+      "names": [
+        "POSTGRES_PASSWORD",
+        "REDIS_PASSWORD"
+      ],
+      "perms": "0444"
     },
     {
       "destination": "/run/vault-agent/shared-arr.env",
-      "names": ["LIDARR_API_KEY", "RADARR_API_KEY", "SONARR_API_KEY"]
+      "names": [
+        "LIDARR_API_KEY",
+        "RADARR_API_KEY",
+        "SONARR_API_KEY"
+      ],
+      "perms": "0444"
     },
     {
       "destination": "/run/vault-agent/shared-grafana.env",
-      "names": ["GRAFANA_ADMIN_PASSWORD", "GRAFANA_ADMIN_USER"]
+      "names": [
+        "GRAFANA_ADMIN_PASSWORD",
+        "GRAFANA_ADMIN_USER"
+      ],
+      "perms": "0444"
     },
     {
       "destination": "/run/vault-agent/media-server.env",
-      "names": ["JELLYSTAT_JWT_SECRET"]
+      "names": [
+        "JELLYSTAT_JWT_SECRET"
+      ],
+      "perms": "0444"
     },
     {
       "destination": "/run/vault-agent/tools.env",
-      "names": ["SEARXNG_SECRET_KEY"]
+      "names": [
+        "SEARXNG_SECRET_KEY"
+      ],
+      "perms": "0444"
     },
     {
       "destination": "/run/vault-agent/media.env",
@@ -94,7 +118,8 @@
         "NORDVPN_USER",
         "QBITTORRENT_PASSWORD",
         "QBITTORRENT_USER"
-      ]
+      ],
+      "perms": "0444"
     },
     {
       "destination": "/run/vault-agent/ai-serving.env",
@@ -108,11 +133,15 @@
         "MINIO_ROOT_PASSWORD",
         "OPENCODE_GO_KEY",
         "UI_PASSWORD"
-      ]
+      ],
+      "perms": "0444"
     },
     {
       "destination": "/run/vault-agent/networking.env",
-      "names": ["CLOUDFLARE_API_TOKEN"]
+      "names": [
+        "CLOUDFLARE_API_TOKEN"
+      ],
+      "perms": "0444"
     },
     {
       "destination": "/run/vault-agent/harbor.env",
@@ -121,14 +150,25 @@
         "HARBOR_DB_PASSWORD",
         "HARBOR_ROBOT_SECRET",
         "HARBOR_ROBOT_USER"
-      ]
+      ],
+      "perms": "0400"
     },
     {
       "destination": "/run/vault-agent/ha-harness.env",
-      "names": ["HA_HARNESS_TOKEN", "LITELLM_API_KEY"]
+      "names": [
+        "HA_HARNESS_TOKEN",
+        "LITELLM_API_KEY"
+      ],
+      "perms": "0444"
     }
   ],
   "schema_version": 1,
+  "service_identity": {
+    "group": "root",
+    "runtime_directory": "/run/vault-agent",
+    "unit": "vault-agent.service",
+    "user": "root"
+  },
   "source": "modules/hosts/discovery/vault.nix",
   "source_sha256": "7a583e3e81ca8df927d5e37d140d3e57fb3cdd7b412a9104bac20f318ee3c42e"
 }

--- a/scripts/export-discovery-vault-contract.py
+++ b/scripts/export-discovery-vault-contract.py
@@ -12,11 +12,13 @@ import re
 
 NAME = re.compile(r"([A-Z][A-Z0-9_]*)=\{\{")
 DESTINATION = re.compile(r'^\s*destination = "([^"]+)"')
+PERMS = re.compile(r'^\s*perms = "([0-7]{4})"')
 
 
 def export(source: pathlib.Path) -> dict[str, object]:
     text = source.read_text()
     pending: list[str] = []
+    current: dict[str, object] | None = None
     renders: list[dict[str, object]] = []
     for line in text.splitlines():
         if "contents = " in line:
@@ -24,14 +26,26 @@ def export(source: pathlib.Path) -> dict[str, object]:
             continue
         match = DESTINATION.match(line)
         if match and pending:
-            renders.append({"destination": match.group(1), "names": sorted(pending)})
+            current = {"destination": match.group(1), "names": sorted(pending)}
             pending = []
+            continue
+        match = PERMS.match(line)
+        if match and current:
+            current["perms"] = match.group(1)
+            renders.append(current)
+            current = None
     names = sorted({name for render in renders for name in render["names"]})
     return {
         "schema_version": 1,
         "owner": "desktop-nixos",
         "source": "modules/hosts/discovery/vault.nix",
         "source_sha256": hashlib.sha256(text.encode()).hexdigest(),
+        "service_identity": {
+            "unit": "vault-agent.service",
+            "user": "root",
+            "group": "root",
+            "runtime_directory": "/run/vault-agent",
+        },
         "names": names,
         "renders": renders,
     }

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -36,6 +36,11 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
             self.assertEqual(contract["names"], sorted(contract["names"]))
             self.assertIn("CLOUDFLARE_API_TOKEN", contract["names"])
             self.assertIn("HARBOR_ROBOT_SECRET", contract["names"])
+            self.assertEqual(
+                contract["service_identity"],
+                {"group": "root", "runtime_directory": "/run/vault-agent", "unit": "vault-agent.service", "user": "root"},
+            )
+            self.assertTrue(all("perms" in render for render in contract["renders"]))
             rendered = generated.read_text()
             self.assertNotIn(".Data.data", rendered)
             self.assertNotIn("{{", rendered)


### PR DESCRIPTION
Adds value-free Vault render permissions and service identity to the owner contract so Servarr can validate DS4 operational invariants offline.