### PR TITLE
docs(secrets): pin DS7 closure authority

### DIFF
--- a/docs/proposals/2026-07-13-stateful-stack-release-hardening-execution-plan.md
+++ b/docs/proposals/2026-07-13-stateful-stack-release-hardening-execution-plan.md
@@ -28,7 +28,7 @@ Leaf repositories land first. Consumers and host orchestration follow only
 after the leaf commit is published and pinned.
 
 Discovery SecretSpec rollout is now tracked independently in Servarr's
-[`machines/discovery/secretspec-inventory.md`](https://github.com/ErikBPF/servarr/blob/9cb834bdcd978fc9ef8d779114e10d85fa3ee0c7/machines/discovery/secretspec-inventory.md).
+[`machines/discovery/secretspec-inventory.md`](https://github.com/ErikBPF/servarr/blob/097280976683ab82e0dbe53bd60e7b8b07d5613a/machines/discovery/secretspec-inventory.md).
 This execution plan retains K0 and P1 evidence only; its P2–P9 phases do not
 authorize or order additional SecretSpec profiles.
 

--- a/docs/proposals/2026-07-13-stateful-stack-release-hardening.md
+++ b/docs/proposals/2026-07-13-stateful-stack-release-hardening.md
@@ -12,7 +12,7 @@ criteria; the merged execution plan is authoritative for rollout order.
 
 **SecretSpec authority update (2026-07-21):** Discovery SecretSpec scope,
 ordering, and status now live in Servarr's
-[`machines/discovery/secretspec-inventory.md`](https://github.com/ErikBPF/servarr/blob/9cb834bdcd978fc9ef8d779114e10d85fa3ee0c7/machines/discovery/secretspec-inventory.md).
+[`machines/discovery/secretspec-inventory.md`](https://github.com/ErikBPF/servarr/blob/097280976683ab82e0dbe53bd60e7b8b07d5613a/machines/discovery/secretspec-inventory.md).
 This proposal retains the architecture and historical acceptance evidence; it
 does not define future Discovery SecretSpec profiles.
 


### PR DESCRIPTION
Pins the completed Servarr SecretSpec DS0-DS7 rollout authority. DS8 runtime adoption remains explicitly deferred.