### PR TITLE
Add Ponytail agent integrations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1167,6 +1167,22 @@
         "url": "https://flakehub.com/f/ErikBPF/opencode-flake/%2A"
       }
     },
+    "ponytail": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784151135,
+        "narHash": "sha256-Y7d4s7uqjH6IbEXhqAiQ+yaxr6iiGcv2X64LuMtG1T8=",
+        "owner": "DietrichGebert",
+        "repo": "ponytail",
+        "rev": "16f29800fd2681bdf24f3eb4ccffe38be3baec6b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DietrichGebert",
+        "repo": "ponytail",
+        "type": "github"
+      }
+    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat_3",
@@ -1282,6 +1298,7 @@
         "nixpkgs-orca": "nixpkgs-orca",
         "nixvim": "nixvim",
         "opencode-flake": "opencode-flake",
+        "ponytail": "ponytail",
         "quickshell": "quickshell",
         "sops-nix": "sops-nix",
         "stylix": "stylix"

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    ponytail = {
+      url = "github:DietrichGebert/ponytail";
+      flake = false;
+    };
+
     # Terminal multiplexer for AI coding agents (claude-code/codex/opencode/
     # hermes). Third-party Rust flake — pinned to a release tag, and left on
     # its own nixpkgs (no `follows`) so the Rust toolchain it builds against

--- a/modules/dev/claude-code.nix
+++ b/modules/dev/claude-code.nix
@@ -1,5 +1,18 @@
-_: {
-  flake.modules.home.claude-code = {pkgs, ...}: {
+{inputs, ...}: {
+  flake.modules.home.claude-code = {
+    config,
+    lib,
+    pkgs,
+    ...
+  }: {
     home.packages = [pkgs.claude-code];
+
+    home.activation.installClaudePonytail = lib.hm.dag.entryAfter ["installPackages"] ''
+      if ! ${config.home.profileDirectory}/bin/claude plugin list --json |
+        ${lib.getExe pkgs.jq} -e 'any(.[]; .id == "ponytail@ponytail")' >/dev/null; then
+        run ${config.home.profileDirectory}/bin/claude plugin marketplace add ${inputs.ponytail} --scope user
+        run ${config.home.profileDirectory}/bin/claude plugin install ponytail@ponytail --scope user
+      fi
+    '';
   };
 }

--- a/modules/dev/codex.nix
+++ b/modules/dev/codex.nix
@@ -1,5 +1,10 @@
 {inputs, ...}: {
-  flake.modules.home.codex = _: {
+  flake.modules.home.codex = {
+    config,
+    lib,
+    pkgs,
+    ...
+  }: {
     imports = [inputs.codex-flake.homeManagerModules.withPackage];
 
     programs.codex-profile = {
@@ -8,5 +13,14 @@
       rtk.enable = true;
       style.enable = true;
     };
+
+    home.activation.installCodexPonytail = lib.hm.dag.entryAfter ["installPackages"] ''
+      export PATH=${lib.makeBinPath [pkgs.git]}:$PATH
+      if ! ${lib.getExe config.programs.codex.package} plugin list --json |
+        ${lib.getExe pkgs.jq} -e 'any(.installed[]; .pluginId == "ponytail@ponytail")' >/dev/null; then
+        run ${lib.getExe config.programs.codex.package} plugin marketplace add ${inputs.ponytail}
+        run ${lib.getExe config.programs.codex.package} plugin add ponytail@ponytail
+      fi
+    '';
   };
 }

--- a/modules/dev/opencode.nix
+++ b/modules/dev/opencode.nix
@@ -38,7 +38,10 @@
     # /run/secrets/opencode/*).
     programs.opencode.settings = {
       instructions = ["AGENTS.md"];
-      plugin = ["./plugins/rtk.ts"];
+      plugin = [
+        "./plugins/rtk.ts"
+        "${inputs.ponytail}/.opencode/plugins/ponytail.mjs"
+      ];
       model = "litellm/glm-5";
 
       provider = {


### PR DESCRIPTION
## Summary
- install Ponytail for Claude Code and Codex through Home Manager activation
- load Ponytail directly in OpenCode
- pin the shared Ponytail source as a non-flake input

## Verification
- `just lint`
- `just fmt-check`
- `just dry endeavour`

No local `nix flake check` was run.