### PR TITLE
fix(secrets): prepare DS8 tools pilot

### DIFF
--- a/justfile
+++ b/justfile
@@ -2327,6 +2327,22 @@ refresh-vault-agent target:
     IP="$(just _host-ip {{target}})"
     ssh -p 2222 erik@"$IP" 'sudo systemctl restart vault-agent.service; sudo systemctl is-active vault-agent.service; for _ in $(seq 1 100); do sudo test -s /run/vault-agent/ha-harness.env && break; sleep 0.1; done; sudo test -s /run/vault-agent/ha-harness.env; sudo journalctl -u vault-agent.service --no-pager -n20; sudo awk -F= '"'"'$1 == "LITELLM_API_KEY" {print $2}'"'"' /run/vault-agent/ha-harness.env | sha256sum | sed "s/ .*$/  ha-harness LITELLM_API_KEY/"'
 
+# Prove the DS8 tools render is fresh and least-privilege without printing it.
+verify-tools-secret-render:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP="$(just _host-ip discovery)"
+    ssh -p 2222 erik@"$IP" '
+      set -euo pipefail
+      sudo systemctl is-active vault-agent.service
+      test "$(sudo stat -c '"'"'%a %U %G'"'"' /run/vault-agent/tools.env)" = "440 root docker"
+      sudo -u erik test -r /run/vault-agent/tools.env
+      sudo -u nobody test ! -r /run/vault-agent/tools.env
+      sudo find /run/vault-agent/tools.env -mmin -15 -print -quit | grep -q .
+      test "$(sudo cut -d= -f1 /run/vault-agent/tools.env)" = SEARXNG_SECRET_KEY
+      echo "tools_render=ready mode=0440 owner=root group=docker fresh=true"
+    '
+
 # Permanently remove the seven disposable AI containers, their seven exact
 # images, and /fast/ai-models. The helper re-inventories and fails closed.
 kepler-retire-ai-serving-user-approved:

--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -106,10 +106,11 @@
     },
     {
       "destination": "/run/vault-agent/tools.env",
+      "group": "docker",
       "names": [
         "SEARXNG_SECRET_KEY"
       ],
-      "perms": "0444"
+      "perms": "0440"
     },
     {
       "destination": "/run/vault-agent/media.env",
@@ -170,5 +171,5 @@
     "user": "root"
   },
   "source": "modules/hosts/discovery/vault.nix",
-  "source_sha256": "7a583e3e81ca8df927d5e37d140d3e57fb3cdd7b412a9104bac20f318ee3c42e"
+  "source_sha256": "f351b6e69027ffc88f55ac9d9feea965eefb2830d07229f0caa0d59e152ebfcf"
 }

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -259,7 +259,10 @@
           template {
             contents = "{{ with secret \"secret/data/home/tools\" }}SEARXNG_SECRET_KEY={{ .Data.data.SEARXNG_SECRET_KEY }}\n{{ end }}"
             destination = "/run/vault-agent/tools.env"
-            perms = "0444"
+            perms = "0440"
+            exec {
+              command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/tools.env"]
+            }
           }
           template {
             contents = "{{ with secret \"secret/data/home/media\" }}NORDVPN_USER={{ .Data.data.NORDVPN_USER }}\nNORDVPN_PASSWORD={{ .Data.data.NORDVPN_PASSWORD }}\nQBITTORRENT_USER={{ .Data.data.QBITTORRENT_USER }}\nQBITTORRENT_PASSWORD={{ .Data.data.QBITTORRENT_PASSWORD }}\n{{ end }}"

--- a/scripts/export-discovery-vault-contract.py
+++ b/scripts/export-discovery-vault-contract.py
@@ -13,6 +13,7 @@ import re
 NAME = re.compile(r"([A-Z][A-Z0-9_]*)=\{\{")
 DESTINATION = re.compile(r'^\s*destination = "([^"]+)"')
 PERMS = re.compile(r'^\s*perms = "([0-7]{4})"')
+CHGRP = re.compile(r'^\s*command = \["[^"]*/chgrp", "([^"]+)", "([^"]+)"\]')
 
 
 def export(source: pathlib.Path) -> dict[str, object]:
@@ -34,6 +35,15 @@ def export(source: pathlib.Path) -> dict[str, object]:
             current["perms"] = match.group(1)
             renders.append(current)
             current = None
+            continue
+        match = CHGRP.match(line)
+        if match:
+            group, destination = match.groups()
+            render = next(
+                (row for row in renders if row["destination"] == destination), None
+            )
+            if render is not None:
+                render["group"] = group
     names = sorted({name for render in renders for name in render["names"]})
     return {
         "schema_version": 1,

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -14,6 +14,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 SOURCE = ROOT / "modules/hosts/discovery/vault.nix"
 EXPORTER = ROOT / "scripts/export-discovery-vault-contract.py"
 ARTIFACT = ROOT / "modules/hosts/discovery/vault-env-contract.json"
+JUSTFILE = ROOT / "justfile"
 
 
 class DiscoveryVaultSurfaceTest(unittest.TestCase):
@@ -51,6 +52,14 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
             rendered = generated.read_text()
             self.assertNotIn(".Data.data", rendered)
             self.assertNotIn("{{", rendered)
+
+    def test_tools_render_has_value_free_live_verification_recipe(self):
+        justfile = JUSTFILE.read_text()
+        self.assertIn("verify-tools-secret-render:", justfile)
+        self.assertIn("sudo -u erik test -r /run/vault-agent/tools.env", justfile)
+        self.assertIn("sudo -u nobody test ! -r /run/vault-agent/tools.env", justfile)
+        self.assertIn("sudo stat -c", justfile)
+        self.assertIn("440 root docker", justfile)
 
 
 if __name__ == "__main__":

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -41,6 +41,13 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
                 {"group": "root", "runtime_directory": "/run/vault-agent", "unit": "vault-agent.service", "user": "root"},
             )
             self.assertTrue(all("perms" in render for render in contract["renders"]))
+            tools = next(
+                render for render in contract["renders"]
+                if render["destination"] == "/run/vault-agent/tools.env"
+            )
+            self.assertEqual(tools["perms"], "0440")
+            self.assertEqual(tools["group"], "docker")
+            self.assertIn('command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/tools.env"]', SOURCE.read_text())
             rendered = generated.read_text()
             self.assertNotIn(".Data.data", rendered)
             self.assertNotIn("{{", rendered)


### PR DESCRIPTION
## Summary
- restrict the tools Vault render to root:docker 0440
- export group ownership in the value-free provider contract
- add a remote value-free ownership/freshness verification recipe

## Verification
- just lint
- just fmt-check
- just dry discovery
- python3 -m unittest tests/discovery-secret-contract/test_vault_surface.py

No SecretSpec runtime cutover or stack lifecycle action.