### PR TITLE
fix(secrets): verify actual tools render access

### DIFF
--- a/justfile
+++ b/justfile
@@ -2336,8 +2336,11 @@ verify-tools-secret-render:
       set -euo pipefail
       sudo systemctl is-active vault-agent.service
       test "$(sudo stat -c '"'"'%a %U %G'"'"' /run/vault-agent/tools.env)" = "440 root docker"
-      sudo -u erik test -r /run/vault-agent/tools.env
-      sudo -u nobody test ! -r /run/vault-agent/tools.env
+      sudo -u erik head -c0 /run/vault-agent/tools.env
+      if sudo -u nobody head -c0 /run/vault-agent/tools.env 2>/dev/null; then
+        echo "nobody unexpectedly read tools render" >&2
+        exit 1
+      fi
       sudo find /run/vault-agent/tools.env -mmin -15 -print -quit | grep -q .
       test "$(sudo cut -d= -f1 /run/vault-agent/tools.env)" = SEARXNG_SECRET_KEY
       echo "tools_render=ready mode=0440 owner=root group=docker fresh=true"

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -56,8 +56,8 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
     def test_tools_render_has_value_free_live_verification_recipe(self):
         justfile = JUSTFILE.read_text()
         self.assertIn("verify-tools-secret-render:", justfile)
-        self.assertIn("sudo -u erik test -r /run/vault-agent/tools.env", justfile)
-        self.assertIn("sudo -u nobody test ! -r /run/vault-agent/tools.env", justfile)
+        self.assertIn("sudo -u erik head -c0 /run/vault-agent/tools.env", justfile)
+        self.assertIn("sudo -u nobody head -c0 /run/vault-agent/tools.env", justfile)
         self.assertIn("sudo stat -c", justfile)
         self.assertIn("440 root docker", justfile)
 


### PR DESCRIPTION
Replace sudo test -r with zero-byte opens. This proves effective access without printing secret content.

Live evidence after the permission deployment: mode 0440, owner root, group docker, fresh render, erik read succeeds, nobody read fails.