### PR TITLE
feat(secrets): cut tools over to SecretSpec

### DIFF
--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -18,6 +18,7 @@ _: {
         "ha-harness" = ["ha-harness"];
         infra = ["shared-db"];
       };
+      secretSpecRuntimeProfiles.tools = "tools";
       stacks = [
         # shared.yml has no services on discovery (alloy/syncthing/etc run natively)
         "infra" # postgres, redis, vault, adguard

--- a/modules/server/orchestration.nix
+++ b/modules/server/orchestration.nix
@@ -60,6 +60,16 @@ in {
         '';
       };
 
+      secretSpecRuntimeProfiles = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = {};
+        description = ''
+          Stack-to-profile map for approved SecretSpec runtime boundaries. The
+          matching vault-agent env basename is resolved by SecretSpec and is not
+          also passed directly to Compose.
+        '';
+      };
+
       dockerSocket = lib.mkOption {
         type = lib.types.str;
         default = "unix:///run/user/1000/podman/podman.sock";
@@ -99,9 +109,24 @@ in {
       # Stacks in vaultEnvStacks get one --env-file per listed vault-agent render,
       # layered after the sops .env (later --env-file wins for overlapping keys).
       makeService = idx: name: let
+        secretSpecProfile = cfg.secretSpecRuntimeProfiles.${name} or null;
+        secretSpecEnv =
+          if secretSpecProfile == null
+          then name
+          else secretSpecProfile;
+        vaultBasenames = cfg.vaultEnvStacks.${name} or [];
         vaultEnvFlags =
           lib.concatMapStrings (b: " --env-file /run/vault-agent/${b}.env")
-          (cfg.vaultEnvStacks.${name} or []);
+          (lib.filter (b: b != secretSpecProfile) vaultBasenames);
+        secretSpecPrefix = lib.optionalString (secretSpecProfile != null) "${pkgs.secretspec}/bin/secretspec run --file ${cfg.composeDir}/secretspec.toml --profile ${secretSpecEnv} --provider dotenv:/run/vault-agent/${secretSpecEnv}.env --reason discovery-${name}-production-runtime -- ";
+        secretSpecWait = lib.optionalString (secretSpecProfile != null) " --wait";
+        secretSpecPreflight = pkgs.writeShellScript "secretspec-${name}-preflight" ''
+          set -euo pipefail
+          ${pkgs.systemd}/bin/systemctl is-active vault-agent.service >/dev/null
+          render=/run/vault-agent/${secretSpecEnv}.env
+          [ "$(${pkgs.coreutils}/bin/stat -c '%a %U %G' "$render")" = "440 root docker" ]
+          ${pkgs.coreutils}/bin/head -c0 "$render"
+        '';
       in {
         "podman-compose-${name}" = {
           Unit = {
@@ -131,8 +156,9 @@ in {
             EnvironmentFile = "-${cfg.composeDir}/.env";
             # Docker socket — rootless Podman by default, override for rootful Docker.
             Environment = "DOCKER_HOST=${cfg.dockerSocket}";
-            ExecStart = "/run/current-system/sw/bin/docker-compose --project-name ${name} --env-file ${cfg.composeDir}/.env${vaultEnvFlags} -f ${cfg.composeDir}/${name}.yml up -d --remove-orphans";
-            ExecStop = "/run/current-system/sw/bin/docker-compose --project-name ${name} --env-file ${cfg.composeDir}/.env${vaultEnvFlags} -f ${cfg.composeDir}/${name}.yml stop";
+            ExecStartPre = lib.optional (secretSpecProfile != null) secretSpecPreflight;
+            ExecStart = "${secretSpecPrefix}/run/current-system/sw/bin/docker-compose --project-name ${name} --env-file ${cfg.composeDir}/.env${vaultEnvFlags} -f ${cfg.composeDir}/${name}.yml up -d --remove-orphans${secretSpecWait}";
+            ExecStop = "${secretSpecPrefix}/run/current-system/sw/bin/docker-compose --project-name ${name} --env-file ${cfg.composeDir}/.env${vaultEnvFlags} -f ${cfg.composeDir}/${name}.yml stop";
             TimeoutStopSec = 60;
           };
           # Empty WantedBy — these units are enabled (symlinked) but not pulled

--- a/tests/discovery-secret-contract/test_tools_cutover.py
+++ b/tests/discovery-secret-contract/test_tools_cutover.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""DS8 tools SecretSpec runtime wiring contract."""
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+ORCHESTRATION = ROOT / "modules/server/orchestration.nix"
+COMPOSE = ROOT / "modules/hosts/discovery/compose.nix"
+
+
+class ToolsCutoverTest(unittest.TestCase):
+    def test_discovery_enables_only_tools_runtime_profile(self):
+        source = COMPOSE.read_text()
+        self.assertIn('secretSpecRuntimeProfiles.tools = "tools";', source)
+
+    def test_runtime_wrapper_is_fail_closed_and_removes_direct_provider_flag(self):
+        source = ORCHESTRATION.read_text()
+        self.assertIn("secretSpecRuntimeProfiles", source)
+        self.assertIn("${pkgs.secretspec}/bin/secretspec run", source)
+        self.assertIn("--reason discovery-${name}-production-runtime", source)
+        self.assertIn("b != secretSpecProfile", source)
+        self.assertIn("systemctl is-active vault-agent.service", source)
+        self.assertIn("stat -c '%a %U %G'", source)
+        self.assertIn('secretSpecWait = lib.optionalString (secretSpecProfile != null) " --wait";', source)
+        self.assertIn("up -d --remove-orphans${secretSpecWait}", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- wrap only the Discovery tools unit with pinned SecretSpec 0.13
- resolve SEARXNG_SECRET_KEY from the existing Vault Agent render
- remove the direct tools.env Compose flag
- preflight Vault Agent health and render ownership
- wait for Compose health

## Verification
- focused runtime-wiring tests
- just lint
- just fmt-check
- just dry discovery
- evaluated ExecStart argv inspected

Rollback: revert this change and recreate only tools. No provider authority or value changes.