### PR TITLE
fix(secrets): target tools health gate

### DIFF
--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -19,6 +19,7 @@ _: {
         infra = ["shared-db"];
       };
       secretSpecRuntimeProfiles.tools = "tools";
+      secretSpecRuntimeHealthContainers.tools = "searxng";
       stacks = [
         # shared.yml has no services on discovery (alloy/syncthing/etc run natively)
         "infra" # postgres, redis, vault, adguard

--- a/modules/server/orchestration.nix
+++ b/modules/server/orchestration.nix
@@ -70,6 +70,15 @@ in {
         '';
       };
 
+      secretSpecRuntimeHealthContainers = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = {};
+        description = ''
+          Stack-to-container map for targeted post-start health gates on
+          SecretSpec runtime boundaries.
+        '';
+      };
+
       dockerSocket = lib.mkOption {
         type = lib.types.str;
         default = "unix:///run/user/1000/podman/podman.sock";
@@ -110,6 +119,7 @@ in {
       # layered after the sops .env (later --env-file wins for overlapping keys).
       makeService = idx: name: let
         secretSpecProfile = cfg.secretSpecRuntimeProfiles.${name} or null;
+        secretSpecHealthContainer = cfg.secretSpecRuntimeHealthContainers.${name} or null;
         secretSpecEnv =
           if secretSpecProfile == null
           then name
@@ -119,7 +129,6 @@ in {
           lib.concatMapStrings (b: " --env-file /run/vault-agent/${b}.env")
           (lib.filter (b: b != secretSpecProfile) vaultBasenames);
         secretSpecPrefix = lib.optionalString (secretSpecProfile != null) "${pkgs.secretspec}/bin/secretspec run --file ${cfg.composeDir}/secretspec.toml --profile ${secretSpecEnv} --provider dotenv:/run/vault-agent/${secretSpecEnv}.env --reason discovery-${name}-production-runtime -- ";
-        secretSpecWait = lib.optionalString (secretSpecProfile != null) " --wait";
         secretSpecPreflight = pkgs.writeShellScript "secretspec-${name}-preflight" ''
           set -euo pipefail
           ${pkgs.systemd}/bin/systemctl is-active vault-agent.service >/dev/null
@@ -127,6 +136,21 @@ in {
           [ "$(${pkgs.coreutils}/bin/stat -c '%a %U %G' "$render")" = "440 root docker" ]
           ${pkgs.coreutils}/bin/head -c0 "$render"
         '';
+        secretSpecHealthGate =
+          if secretSpecHealthContainer == null
+          then null
+          else
+            pkgs.writeShellScript "secretspec-${name}-health" ''
+              set -euo pipefail
+              health_container="${secretSpecHealthContainer}"
+              for _ in $(${pkgs.coreutils}/bin/seq 1 60); do
+                status="$(${pkgs.docker}/bin/docker inspect --format '{{.State.Health.Status}}' "$health_container" 2>/dev/null || true)"
+                [ "$status" = healthy ] && exit 0
+                [ "$status" = unhealthy ] && exit 1
+                ${pkgs.coreutils}/bin/sleep 2
+              done
+              exit 1
+            '';
       in {
         "podman-compose-${name}" = {
           Unit = {
@@ -157,7 +181,8 @@ in {
             # Docker socket — rootless Podman by default, override for rootful Docker.
             Environment = "DOCKER_HOST=${cfg.dockerSocket}";
             ExecStartPre = lib.optional (secretSpecProfile != null) secretSpecPreflight;
-            ExecStart = "${secretSpecPrefix}/run/current-system/sw/bin/docker-compose --project-name ${name} --env-file ${cfg.composeDir}/.env${vaultEnvFlags} -f ${cfg.composeDir}/${name}.yml up -d --remove-orphans${secretSpecWait}";
+            ExecStart = "${secretSpecPrefix}/run/current-system/sw/bin/docker-compose --project-name ${name} --env-file ${cfg.composeDir}/.env${vaultEnvFlags} -f ${cfg.composeDir}/${name}.yml up -d --remove-orphans";
+            ExecStartPost = lib.optional (secretSpecHealthContainer != null) secretSpecHealthGate;
             ExecStop = "${secretSpecPrefix}/run/current-system/sw/bin/docker-compose --project-name ${name} --env-file ${cfg.composeDir}/.env${vaultEnvFlags} -f ${cfg.composeDir}/${name}.yml stop";
             TimeoutStopSec = 60;
           };

--- a/tests/discovery-secret-contract/test_tools_cutover.py
+++ b/tests/discovery-secret-contract/test_tools_cutover.py
@@ -16,6 +16,7 @@ class ToolsCutoverTest(unittest.TestCase):
     def test_discovery_enables_only_tools_runtime_profile(self):
         source = COMPOSE.read_text()
         self.assertIn('secretSpecRuntimeProfiles.tools = "tools";', source)
+        self.assertIn('secretSpecRuntimeHealthContainers.tools = "searxng";', source)
 
     def test_runtime_wrapper_is_fail_closed_and_removes_direct_provider_flag(self):
         source = ORCHESTRATION.read_text()
@@ -25,8 +26,11 @@ class ToolsCutoverTest(unittest.TestCase):
         self.assertIn("b != secretSpecProfile", source)
         self.assertIn("systemctl is-active vault-agent.service", source)
         self.assertIn("stat -c '%a %U %G'", source)
-        self.assertIn('secretSpecWait = lib.optionalString (secretSpecProfile != null) " --wait";', source)
-        self.assertIn("up -d --remove-orphans${secretSpecWait}", source)
+        self.assertNotIn("secretSpecWait", source)
+        self.assertIn("up -d --remove-orphans", source)
+        self.assertIn("ExecStartPost = lib.optional", source)
+        self.assertIn("/bin/docker inspect --format '{{.State.Health.Status}}'", source)
+        self.assertIn('health_container="${secretSpecHealthContainer}"', source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace stack-wide Compose wait with a targeted SecretSpec post-start health gate
- gate the discovery tools pilot on SearXNG only
- add regression coverage for the production runtime wiring

## Verification
- python3 -m unittest tests/discovery-secret-contract/test_tools_cutover.py
- just lint
- just fmt-check
- just dry discovery