### PR TITLE
feat(secrets): harden ha-harness render

### DIFF
--- a/justfile
+++ b/justfile
@@ -2346,6 +2346,27 @@ verify-tools-secret-render:
       echo "tools_render=ready mode=0440 owner=root group=docker fresh=true"
     '
 
+# Prove the DS8 ha-harness render is fresh and least-privilege without printing it.
+verify-ha-harness-secret-render:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP="$(just _host-ip discovery)"
+    ssh -p 2222 erik@"$IP" '
+      set -euo pipefail
+      sudo systemctl is-active vault-agent.service
+      test "$(sudo stat -c '"'"'%a %U %G'"'"' /run/vault-agent/ha-harness.env)" = "440 root docker"
+      sudo -u erik head -c0 /run/vault-agent/ha-harness.env
+      if sudo -u nobody head -c0 /run/vault-agent/ha-harness.env 2>/dev/null; then
+        echo "nobody unexpectedly read ha-harness render" >&2
+        exit 1
+      fi
+      sudo find /run/vault-agent/ha-harness.env -mmin -15 -print -quit | grep -q .
+      actual="$(sudo cut -d= -f1 /run/vault-agent/ha-harness.env | sort -u)"
+      expected="$(printf "HA_HARNESS_TOKEN\nLITELLM_API_KEY")"
+      test "$actual" = "$expected"
+      echo "ha_harness_render=ready mode=0440 owner=root group=docker fresh=true"
+    '
+
 # Permanently remove the seven disposable AI containers, their seven exact
 # images, and /fast/ai-models. The helper re-inventories and fails closed.
 kepler-retire-ai-serving-user-approved:

--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -156,11 +156,12 @@
     },
     {
       "destination": "/run/vault-agent/ha-harness.env",
+      "group": "docker",
       "names": [
         "HA_HARNESS_TOKEN",
         "LITELLM_API_KEY"
       ],
-      "perms": "0444"
+      "perms": "0440"
     }
   ],
   "schema_version": 1,
@@ -171,5 +172,5 @@
     "user": "root"
   },
   "source": "modules/hosts/discovery/vault.nix",
-  "source_sha256": "f351b6e69027ffc88f55ac9d9feea965eefb2830d07229f0caa0d59e152ebfcf"
+  "source_sha256": "1a93f305afc5555d94cc37cdc2d08b2d304a832252422e59b49eaa67336af1e2"
 }

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -290,7 +290,10 @@
           template {
             contents = "{{ with secret \"secret/data/home/ha-harness\" }}LITELLM_API_KEY={{ .Data.data.LITELLM_API_KEY }}\nHA_HARNESS_TOKEN={{ .Data.data.HA_HARNESS_TOKEN }}\n{{ end }}"
             destination = "/run/vault-agent/ha-harness.env"
-            perms = "0444"
+            perms = "0440"
+            exec {
+              command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/ha-harness.env"]
+            }
           }
         ''}";
       };

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -49,6 +49,12 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
             self.assertEqual(tools["perms"], "0440")
             self.assertEqual(tools["group"], "docker")
             self.assertIn('command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/tools.env"]', SOURCE.read_text())
+            ha_harness = next(
+                render for render in contract["renders"]
+                if render["destination"] == "/run/vault-agent/ha-harness.env"
+            )
+            self.assertEqual(ha_harness["perms"], "0440")
+            self.assertEqual(ha_harness["group"], "docker")
             rendered = generated.read_text()
             self.assertNotIn(".Data.data", rendered)
             self.assertNotIn("{{", rendered)
@@ -60,6 +66,14 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
         self.assertIn("sudo -u nobody head -c0 /run/vault-agent/tools.env", justfile)
         self.assertIn("sudo stat -c", justfile)
         self.assertIn("440 root docker", justfile)
+
+    def test_ha_harness_render_has_value_free_live_verification_recipe(self):
+        justfile = JUSTFILE.read_text()
+        self.assertIn("verify-ha-harness-secret-render:", justfile)
+        self.assertIn("sudo -u erik head -c0 /run/vault-agent/ha-harness.env", justfile)
+        self.assertIn("sudo -u nobody head -c0 /run/vault-agent/ha-harness.env", justfile)
+        self.assertIn('sort -u', justfile)
+        self.assertIn('HA_HARNESS_TOKEN\\nLITELLM_API_KEY', justfile)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- harden ha-harness Vault Agent render to 0440 root:docker
- add value-free exact-name and access verifier
- refresh the vendored Vault surface contract

## Verification
- focused Vault surface tests
- just lint
- just fmt-check
- just dry discovery