### PR TITLE
fix(kindle): tolerate unrelated repo advances

### DIFF
--- a/modules/hosts/discovery/_kindle-release-agent.py
+++ b/modules/hosts/discovery/_kindle-release-agent.py
@@ -818,21 +818,11 @@ def activate_revision(runner, commit):
 def verify_active_commit(runner, commit):
     if not COMMIT_RE.fullmatch(commit):
         raise ValueError("invalid active commit")
-    actual = runner.run(
-        [
-            "runuser",
-            "-u",
-            "erik",
-            "--",
-            "git",
-            "-C",
-            str(SERVARR_REPO),
-            "rev-parse",
-            "HEAD",
-        ]
-    ).strip()
-    if actual != commit:
-        raise ValueError(f"active Servarr commit mismatch: expected {commit}, got {actual}")
+    git = ["runuser", "-u", "erik", "--", "git", "-C", str(SERVARR_REPO)]
+    expected = runner.run(git + ["rev-parse", f"{commit}:{COMPOSE_PATH}"]).strip()
+    actual = runner.run(git + ["hash-object", str(SERVARR_REPO / COMPOSE_PATH)]).strip()
+    if actual != expected:
+        raise ValueError("active Kindle compose mismatch for recorded commit")
 
 
 def recreate_kindle(runner, uid):

--- a/tests/kindle-release-agent/test_agent.py
+++ b/tests/kindle-release-agent/test_agent.py
@@ -98,6 +98,23 @@ class PinContract(unittest.TestCase):
                 f"    image: {self.pin}\n",
             )
 
+    def test_active_revision_allows_unrelated_repository_advances(self):
+        runner = mock.Mock()
+        runner.run.side_effect = ["expected-blob\n", "expected-blob\n"]
+        commit = "b" * 40
+        self.agent.verify_active_commit(runner, commit)
+        commands = runner.run.call_args_list
+        self.assertEqual(len(commands), 2)
+        self.assertIn(f"{commit}:{self.agent.COMPOSE_PATH}", commands[0].args[0])
+        self.assertIn("hash-object", commands[1].args[0])
+        self.assertNotIn("HEAD", commands[0].args[0] + commands[1].args[0])
+
+    def test_active_revision_rejects_compose_drift(self):
+        runner = mock.Mock()
+        runner.run.side_effect = ["expected-blob\n", "different-blob\n"]
+        with self.assertRaisesRegex(ValueError, "active Kindle compose mismatch"):
+            self.agent.verify_active_commit(runner, "b" * 40)
+
 
 class PhaseContract(unittest.TestCase):
     def setUp(self):
@@ -1645,7 +1662,8 @@ class BootstrapContract(unittest.TestCase):
             "",
             self.digest + "\n",
             self.digest + "\n",
-            self.commit + "\n",
+            "compose-blob\n",
+            "compose-blob\n",
             json.dumps([self.container]),
             json.dumps([self.image]),
         ]
@@ -1656,7 +1674,7 @@ class BootstrapContract(unittest.TestCase):
         events = []
 
         def now():
-            self.assertEqual(len(runner.calls), 11)
+            self.assertEqual(len(runner.calls), 12)
             events.append("clock")
             return "2026-07-20T10:11:12Z"
 
@@ -1751,7 +1769,7 @@ class BootstrapContract(unittest.TestCase):
         self.assertEqual(runner.environment_calls, [])
 
     def test_each_subprocess_or_png_gate_failure_prevents_persistence(self):
-        for fail_at in range(11):
+        for fail_at in range(12):
             with self.subTest(fail_at=fail_at):
                 runner = self.Runner(self.outputs(), fail_at=fail_at)
                 persisted = []


### PR DESCRIPTION
## Summary
- revalidate the active Kindle Compose blob against the recorded release commit
- allow unrelated Servarr HEAD advancement
- continue failing closed on Kindle Compose drift

## Verification
- Kindle release-agent suite: 95 pass
- `just lint`
- `just fmt-check`
- `just dry discovery`
- `/review`: no blocking findings

## Incident
Unrelated Servarr secrets merges advanced the host checkout while the deployed Kindle Compose file remained correct. The old whole-HEAD invariant blocked Discovery activation and triggered a clean deploy-rs rollback.