### PR TITLE
fix(secrets): parse SecretSpec profile tables

### DIFF
--- a/modules/server/_secretspec-runtime-projection.py
+++ b/modules/server/_secretspec-runtime-projection.py
@@ -112,14 +112,12 @@ def main() -> None:
     try:
         with args.manifest.open("rb") as handle:
             manifest = tomllib.load(handle)
-        expected = manifest["profiles"][args.profile]
-        if not isinstance(expected, list) or not expected or any(
-            not isinstance(name, str) or not NAME.fullmatch(name) for name in expected
-        ):
+        profile = manifest["profiles"][args.profile]
+        if not isinstance(profile, dict) or not profile:
             raise ProjectionError("invalid or empty SecretSpec profile")
-        expected_names = set(expected)
-        if len(expected_names) != len(expected):
-            raise ProjectionError("duplicate SecretSpec profile name")
+        expected_names = set(profile)
+        if any(not NAME.fullmatch(name) for name in expected_names):
+            raise ProjectionError("invalid SecretSpec profile name")
         source_config_names = set(args.source_config_name)
         if len(source_config_names) != len(args.source_config_name) or any(
             not NAME.fullmatch(name) for name in source_config_names

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -20,7 +20,9 @@ class RuntimeProjectionTest(unittest.TestCase):
     def setUp(self):
         self.temporary = tempfile.TemporaryDirectory()
         self.root = pathlib.Path(self.temporary.name)
-        (self.root / "secretspec.toml").write_text('[profiles]\nhomepage = ["A", "B"]\n')
+        (self.root / "secretspec.toml").write_text(
+            '[profiles.homepage]\nA = { required = true }\nB = { required = true }\n'
+        )
         (self.root / ".env").write_text("# config\nPORT=8080\nA=legacy-a\nB=legacy-b\n")
         (self.root / "one.env").write_text("A=sentinel-a\n")
         (self.root / "two.env").write_text("B=sentinel-b\n")


### PR DESCRIPTION
## Summary
- parse real `[profiles.<name>]` SecretSpec tables
- derive exact provider closure from table keys
- replace synthetic list fixture with production-shaped TOML

## Verification
- projection contract suite: 13 pass
- `just lint`
- `just fmt-check`
- `just dry discovery`
- `/review`: no blocking findings

## Incident
The first framework start failed closed before Compose with `invalid or empty SecretSpec profile`. Existing containers were not recreated; provider projection was not published.