### PR TITLE
feat(secrets): cut homepage over to SecretSpec

### DIFF
--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -22,6 +22,9 @@ _: {
       secretSpecRuntimeHealthContainers.tools = "searxng";
       secretSpecRuntimeProfiles.ha-harness = "ha-harness";
       secretSpecRuntimeHealthContainers.ha-harness = "ha-harness";
+      secretSpecRuntimeProfiles.homepage = "homepage";
+      secretSpecRuntimeSourceConfigNames.homepage = ["GRAFANA_ADMIN_USER"];
+      secretSpecRuntimeHealthContainers.homepage = "homepage";
       stacks = [
         # shared.yml has no services on discovery (alloy/syncthing/etc run natively)
         "infra" # postgres, redis, vault, adguard

--- a/tests/discovery-secret-contract/test_homepage_cutover.py
+++ b/tests/discovery-secret-contract/test_homepage_cutover.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Homepage SecretSpec runtime wiring contract."""
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+COMPOSE = ROOT / "modules/hosts/discovery/compose.nix"
+
+
+class HomepageCutoverTest(unittest.TestCase):
+    def test_homepage_uses_atomic_projection_and_targeted_health(self):
+        source = COMPOSE.read_text()
+        self.assertIn('secretSpecRuntimeProfiles.homepage = "homepage";', source)
+        self.assertIn(
+            'secretSpecRuntimeSourceConfigNames.homepage = ["GRAFANA_ADMIN_USER"];',
+            source,
+        )
+        self.assertIn('secretSpecRuntimeHealthContainers.homepage = "homepage";', source)
+        self.assertIn('homepage = ["shared-arr" "shared-grafana"];', source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- activate homepage SecretSpec runtime profile
- merge shared-arr + shared-grafana atomically
- project authoritative nonsecret `GRAFANA_ADMIN_USER` into config-only env
- gate completion on homepage container health

## Verification
- Discovery secret contracts: 14 pass
- `just lint`
- `just fmt-check`
- `just dry discovery`
- `/review`: no findings

Critical profiles remain unchanged.