### PR TITLE
feat(secrets): filter shared render surplus

### DIFF
--- a/modules/server/_secretspec-runtime-projection.py
+++ b/modules/server/_secretspec-runtime-projection.py
@@ -105,6 +105,7 @@ def main() -> None:
     parser.add_argument("--legacy-env", type=pathlib.Path, required=True)
     parser.add_argument("--source", type=pathlib.Path, action="append", required=True)
     parser.add_argument("--source-config-name", action="append", default=[])
+    parser.add_argument("--ignored-source-name", action="append", default=[])
     parser.add_argument("--output-dir", type=pathlib.Path, required=True)
     parser.add_argument("--max-age-seconds", type=int, default=900)
     args = parser.parse_args()
@@ -125,7 +126,14 @@ def main() -> None:
             raise ProjectionError("invalid or duplicate source config name")
         if expected_names & source_config_names:
             raise ProjectionError("source config overlaps SecretSpec profile")
-        allowed_names = expected_names | source_config_names
+        ignored_source_names = set(args.ignored_source_name)
+        if len(ignored_source_names) != len(args.ignored_source_name) or any(
+            not NAME.fullmatch(name) for name in ignored_source_names
+        ):
+            raise ProjectionError("invalid or duplicate ignored source name")
+        if ignored_source_names & (expected_names | source_config_names):
+            raise ProjectionError("ignored source name overlaps emitted name")
+        allowed_names = expected_names | source_config_names | ignored_source_names
 
         now = time.time()
         merged: dict[str, str] = {}
@@ -175,7 +183,8 @@ def main() -> None:
         atomic_publish(args.output_dir, provider, config)
         print(
             f"projection=ready profile={args.profile} names={len(expected_names)} "
-            f"source_config_names={len(source_config_names)}"
+            f"source_config_names={len(source_config_names)} "
+            f"ignored_source_names={len(ignored_source_names)}"
         )
     except (OSError, KeyError, TypeError, ProjectionError, tomllib.TOMLDecodeError) as error:
         print(f"ERROR: {error}", file=sys.stderr)

--- a/modules/server/orchestration.nix
+++ b/modules/server/orchestration.nix
@@ -88,6 +88,15 @@ in {
         '';
       };
 
+      secretSpecRuntimeIgnoredSourceNames = lib.mkOption {
+        type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+        default = {};
+        description = ''
+          Names present in a shared Vault render but unused by a runtime
+          profile. They are accepted for source closure and emitted nowhere.
+        '';
+      };
+
       secretSpecRuntimeMaxAgeSeconds = lib.mkOption {
         type = lib.types.ints.positive;
         default = 900;
@@ -146,6 +155,7 @@ in {
         secretSpecProfile = cfg.secretSpecRuntimeProfiles.${name} or null;
         secretSpecHealthContainer = cfg.secretSpecRuntimeHealthContainers.${name} or null;
         secretSpecSourceConfigNames = cfg.secretSpecRuntimeSourceConfigNames.${name} or [];
+        secretSpecIgnoredSourceNames = cfg.secretSpecRuntimeIgnoredSourceNames.${name} or [];
         vaultBasenames = cfg.vaultEnvStacks.${name} or [];
         vaultEnvFlags =
           lib.concatMapStrings (b: " --env-file /run/vault-agent/${b}.env")
@@ -160,10 +170,11 @@ in {
           else runtimeConfig;
         projectionSourceFlags = lib.concatMapStrings (b: " --source /run/vault-agent/${b}.env") vaultBasenames;
         projectionConfigFlags = lib.concatMapStrings (n: " --source-config-name ${n}") secretSpecSourceConfigNames;
+        projectionIgnoredFlags = lib.concatMapStrings (n: " --ignored-source-name ${n}") secretSpecIgnoredSourceNames;
         secretSpecPrefix = lib.optionalString (secretSpecProfile != null) "${pkgs.secretspec}/bin/secretspec run --file ${cfg.composeDir}/secretspec.toml --profile ${secretSpecProfile} --provider dotenv:${runtimeProvider} --reason discovery-${name}-production-runtime -- ";
         secretSpecPreflight = [
           "${pkgs.systemd}/bin/systemctl is-active vault-agent.service"
-          "${secretSpecRuntimeProjection}/bin/secretspec-runtime-projection --manifest ${cfg.composeDir}/secretspec.toml --profile ${secretSpecProfile} --legacy-env ${cfg.composeDir}/.env${projectionSourceFlags}${projectionConfigFlags} --output-dir ${runtimeOutputDir} --max-age-seconds ${toString cfg.secretSpecRuntimeMaxAgeSeconds}"
+          "${secretSpecRuntimeProjection}/bin/secretspec-runtime-projection --manifest ${cfg.composeDir}/secretspec.toml --profile ${secretSpecProfile} --legacy-env ${cfg.composeDir}/.env${projectionSourceFlags}${projectionConfigFlags}${projectionIgnoredFlags} --output-dir ${runtimeOutputDir} --max-age-seconds ${toString cfg.secretSpecRuntimeMaxAgeSeconds}"
         ];
         secretSpecHealthGate =
           if secretSpecHealthContainer == null

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -30,7 +30,10 @@ class RuntimeProjectionTest(unittest.TestCase):
     def tearDown(self):
         self.temporary.cleanup()
 
-    def run_projection(self, *sources: str, max_age: int = 900, source_config_names=()):
+    def run_projection(
+        self, *sources: str, max_age: int = 900, source_config_names=(),
+        ignored_source_names=(),
+    ):
         command = [
             "python3", str(SCRIPT), "--manifest", str(self.root / "secretspec.toml"),
             "--profile", "homepage", "--legacy-env", str(self.root / ".env"),
@@ -41,6 +44,8 @@ class RuntimeProjectionTest(unittest.TestCase):
             command.extend(["--source", str(self.root / source)])
         for name in source_config_names:
             command.extend(["--source-config-name", name])
+        for name in ignored_source_names:
+            command.extend(["--ignored-source-name", name])
         return subprocess.run(command, text=True, capture_output=True, check=False)
 
     def test_merges_exact_provider_and_removes_secrets_from_compose_env(self):
@@ -87,6 +92,17 @@ class RuntimeProjectionTest(unittest.TestCase):
         self.assertEqual((current / "config.env").read_text(), "PORT=8080\nUSER=source-user\n")
         self.assertNotIn("source-user", result.stdout + result.stderr)
 
+    def test_declared_shared_source_surplus_is_emitted_nowhere(self):
+        (self.root / "two.env").write_text("B=sentinel-b\nREDIS_PASSWORD=ignored-value\n")
+        result = self.run_projection(
+            "one.env", "two.env", ignored_source_names=("REDIS_PASSWORD",)
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        current = self.root / "runtime/current"
+        self.assertEqual((current / "provider.env").read_text(), "A=sentinel-a\nB=sentinel-b\n")
+        self.assertNotIn("REDIS_PASSWORD", (current / "config.env").read_text())
+        self.assertNotIn("ignored-value", result.stdout + result.stderr)
+
     def test_empty_malformed_and_stale_inputs_fail_closed(self):
         for content in ("A=\nB=sentinel-b\n", "A\nB=sentinel-b\n"):
             (self.root / "one.env").write_text(content)
@@ -111,6 +127,8 @@ class RuntimeProjectionTest(unittest.TestCase):
         self.assertIn("--max-age-seconds ${toString cfg.secretSpecRuntimeMaxAgeSeconds}", source)
         self.assertIn("secretSpecRuntimeSourceConfigNames", source)
         self.assertIn("--source-config-name ${n}", source)
+        self.assertIn("secretSpecRuntimeIgnoredSourceNames", source)
+        self.assertIn("--ignored-source-name ${n}", source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- declare unused names present in shared Vault renders
- require declared names for exact source closure
- emit ignored names into neither provider nor config projection

## Verification
- Discovery secret contracts: 15 pass
- `just lint`
- `just fmt-check`
- `just dry discovery`
- `/review`: no findings

No profile activation. Critical profiles unchanged.