### PR TITLE
fix(secrets): harden compose unit lifecycle

### DIFF
--- a/modules/server/orchestration.nix
+++ b/modules/server/orchestration.nix
@@ -172,6 +172,7 @@ in {
         projectionConfigFlags = lib.concatMapStrings (n: " --source-config-name ${n}") secretSpecSourceConfigNames;
         projectionIgnoredFlags = lib.concatMapStrings (n: " --ignored-source-name ${n}") secretSpecIgnoredSourceNames;
         secretSpecPrefix = lib.optionalString (secretSpecProfile != null) "${pkgs.secretspec}/bin/secretspec run --file ${cfg.composeDir}/secretspec.toml --profile ${secretSpecProfile} --provider dotenv:${runtimeProvider} --reason discovery-${name}-production-runtime -- ";
+        legacyStop = "/run/current-system/sw/bin/docker-compose --project-name ${name} --env-file ${composeEnv}${vaultEnvFlags} -f ${cfg.composeDir}/${name}.yml stop";
         secretSpecPreflight = [
           "${pkgs.systemd}/bin/systemctl is-active vault-agent.service"
           "${secretSpecRuntimeProjection}/bin/secretspec-runtime-projection --manifest ${cfg.composeDir}/secretspec.toml --profile ${secretSpecProfile} --legacy-env ${cfg.composeDir}/.env${projectionSourceFlags}${projectionConfigFlags}${projectionIgnoredFlags} --output-dir ${runtimeOutputDir} --max-age-seconds ${toString cfg.secretSpecRuntimeMaxAgeSeconds}"
@@ -191,6 +192,12 @@ in {
               done
               exit 1
             '';
+        stopStack = pkgs.writeShellScript "stop-compose-${name}" ''
+          set -euo pipefail
+          ${pkgs.docker}/bin/docker ps --quiet \
+            --filter "label=com.docker.compose.project=${name}" \
+            | ${pkgs.findutils}/bin/xargs --no-run-if-empty ${pkgs.docker}/bin/docker stop
+        '';
       in {
         "podman-compose-${name}" = {
           Unit = {
@@ -207,27 +214,35 @@ in {
               );
             Wants = ["servarr-pull.service"];
           };
-          Service = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-            WorkingDirectory = cfg.composeDir;
-            # Retry on failure — handles transient boot-time races
-            # (e.g. homelab-net not ready, port conflicts with previous run).
-            Restart = "on-failure";
-            RestartSec = "30s";
-            StartLimitBurst = 5;
-            # Load .env so compose variable substitution works.
-            EnvironmentFile = lib.optional (secretSpecProfile == null) "-${cfg.composeDir}/.env";
-            # Docker socket — rootless Podman by default, override for rootful Docker.
-            Environment = "DOCKER_HOST=${cfg.dockerSocket}";
-            RuntimeDirectory = lib.optional (secretSpecProfile != null) runtimeDirectory;
-            RuntimeDirectoryMode = lib.optionalString (secretSpecProfile != null) "0700";
-            ExecStartPre = lib.optionals (secretSpecProfile != null) secretSpecPreflight;
-            ExecStart = "${secretSpecPrefix}/run/current-system/sw/bin/docker-compose --project-name ${name} --env-file ${composeEnv}${vaultEnvFlags} -f ${cfg.composeDir}/${name}.yml up -d --remove-orphans";
-            ExecStartPost = lib.optional (secretSpecHealthContainer != null) secretSpecHealthGate;
-            ExecStop = "${secretSpecPrefix}/run/current-system/sw/bin/docker-compose --project-name ${name} --env-file ${composeEnv}${vaultEnvFlags} -f ${cfg.composeDir}/${name}.yml stop";
-            TimeoutStopSec = 60;
-          };
+          Service =
+            {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              WorkingDirectory = cfg.composeDir;
+              # Retry on failure — handles transient boot-time races
+              # (e.g. homelab-net not ready, port conflicts with previous run).
+              Restart = "on-failure";
+              RestartSec = "30s";
+              StartLimitBurst = 5;
+              # Load .env so compose variable substitution works.
+              EnvironmentFile = lib.optional (secretSpecProfile == null) "-${cfg.composeDir}/.env";
+              # Docker socket — rootless Podman by default, override for rootful Docker.
+              Environment = "DOCKER_HOST=${cfg.dockerSocket}";
+              ExecStart = "${secretSpecPrefix}/run/current-system/sw/bin/docker-compose --project-name ${name} --env-file ${composeEnv}${vaultEnvFlags} -f ${cfg.composeDir}/${name}.yml up -d --remove-orphans";
+              ExecStartPost = lib.optional (secretSpecHealthContainer != null) secretSpecHealthGate;
+              # Stop by Compose's project label so shutdown never depends on a
+              # runtime secret projection that may not exist during unit upgrade.
+              ExecStop =
+                if secretSpecProfile == null
+                then legacyStop
+                else "${stopStack}";
+              TimeoutStopSec = 60;
+            }
+            // lib.optionalAttrs (secretSpecProfile != null) {
+              RuntimeDirectory = runtimeDirectory;
+              RuntimeDirectoryMode = "0700";
+              ExecStartPre = secretSpecPreflight;
+            };
           # Empty WantedBy — these units are enabled (symlinked) but not pulled
           # in automatically by default.target during home-manager activation.
           # On boot they start via linger: systemd starts the user session which

--- a/tests/orchestration/test_unit_lifecycle.py
+++ b/tests/orchestration/test_unit_lifecycle.py
@@ -1,0 +1,37 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+MODULE = ROOT / "modules/server/orchestration.nix"
+
+
+class UnitLifecycleTest(unittest.TestCase):
+    def setUp(self):
+        self.source = MODULE.read_text()
+
+    def test_runtime_directory_settings_are_absent_without_a_profile(self):
+        self.assertIn(
+            "// lib.optionalAttrs (secretSpecProfile != null) {",
+            self.source,
+        )
+        self.assertNotIn(
+            'RuntimeDirectoryMode = lib.optionalString (secretSpecProfile != null) "0700";',
+            self.source,
+        )
+
+    def test_stop_does_not_require_runtime_secret_projection(self):
+        stop_script = self.source.split(
+            'stopStack = pkgs.writeShellScript "stop-compose-${name}"', 1
+        )[1].split("      in {", 1)[0]
+        exec_stop = self.source.split("ExecStop =", 1)[1].split(";", 1)[0]
+        self.assertIn("if secretSpecProfile == null", exec_stop)
+        self.assertIn("legacyStop", exec_stop)
+        self.assertIn("stopStack", exec_stop)
+        self.assertIn("com.docker.compose.project=${name}", stop_script)
+        self.assertNotIn("runtimeProvider", stop_script)
+        self.assertNotIn("composeEnv", stop_script)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- omit runtime-directory mode from non-SecretSpec units
- stop SecretSpec stacks by Compose project label without secret projections
- preserve legacy compose shutdown for non-cutover and critical stacks

## Verification
- `pytest -q tests/orchestration/test_unit_lifecycle.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`

## Baseline note
The broader `tests/orchestration` suite has an unrelated existing failure: its P2 justfile scan detects a plain `sudo` already present on `origin/main`.