### PR TITLE
fix(secrets): refresh Vault render witnesses

### DIFF
--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -24,6 +24,7 @@
     bao = "${pkgs.openbao}/bin/bao";
     jq = "${pkgs.jq}/bin/jq";
     sopsFile = self + "/secrets/sops/secrets.yaml";
+    renderedAt = ''# rendered_at={{ timestamp }}\n'';
   in {
     environment.systemPackages = [pkgs.openbao];
 
@@ -156,6 +157,9 @@
         ExecStart = "${pkgs.openbao}/bin/bao agent -config=${pkgs.writeText "vault-agent.hcl" ''
           pid_file = "/run/vault-agent/pid"
           vault { address = "${addr}" }
+          template_config {
+            static_secret_render_interval = "5m"
+          }
           auto_auth {
             method "approle" {
               mount_path = "auth/approle"
@@ -206,7 +210,7 @@
           # WEBHOOK_GRAFANA_ALERTS_SECRET. Renders empty until the key is
           # written to secret/shared/discord (missing keys don't fail render).
           template {
-            contents = "DISCORD_WEBHOOK_INCIDENTS={{ with secret \"secret/data/shared/discord\" }}{{ .Data.data.incidents }}{{ end }}\nDISCORD_WEBHOOK_DEPLOYS={{ with secret \"secret/data/shared/discord\" }}{{ .Data.data.deploys }}{{ end }}\nSCRUTINY_NOTIFY_URLS={{ with secret \"secret/data/shared/discord\" }}{{ .Data.data.scrutiny }}{{ end }}\nWEBHOOK_GRAFANA_ALERTS_SECRET={{ with secret \"secret/data/shared/discord\" }}{{ .Data.data.argus_webhook_hmac }}{{ end }}\n"
+            contents = "${renderedAt}DISCORD_WEBHOOK_INCIDENTS={{ with secret \"secret/data/shared/discord\" }}{{ .Data.data.incidents }}{{ end }}\nDISCORD_WEBHOOK_DEPLOYS={{ with secret \"secret/data/shared/discord\" }}{{ .Data.data.deploys }}{{ end }}\nSCRUTINY_NOTIFY_URLS={{ with secret \"secret/data/shared/discord\" }}{{ .Data.data.scrutiny }}{{ end }}\nWEBHOOK_GRAFANA_ALERTS_SECRET={{ with secret \"secret/data/shared/discord\" }}{{ .Data.data.argus_webhook_hmac }}{{ end }}\n"
             destination = "/run/vault-agent/discord.env"
             perms = "0444"
           }
@@ -217,7 +221,7 @@
           # instead of the sops .env. 0444 so the rootless-compose user reads it
           # (matches discord.env; /run is tmpfs).
           template {
-            contents = "CLOUDFLARE_TUNNEL_TOKEN={{ with secret \"secret/data/home/tunneling\" }}{{ .Data.data.CLOUDFLARE_TUNNEL_TOKEN }}{{ end }}\n"
+            contents = "${renderedAt}CLOUDFLARE_TUNNEL_TOKEN={{ with secret \"secret/data/home/tunneling\" }}{{ .Data.data.CLOUDFLARE_TUNNEL_TOKEN }}{{ end }}\n"
             destination = "/run/vault-agent/tunneling.env"
             perms = "0444"
           }
@@ -225,7 +229,7 @@
           # GRAFANA_ADMIN_{USER,PASSWORD} are shared with homepage → in the
           # shared-grafana render above, not here.
           template {
-            contents = "{{ with secret \"secret/data/home/monitoring\" }}GRAFANA_SECRET_KEY={{ .Data.data.GRAFANA_SECRET_KEY }}\nHEALTHCHECKS_SECRET_KEY={{ .Data.data.HEALTHCHECKS_SECRET_KEY }}\nHEALTHCHECKS_SUPERUSER_PASSWORD={{ .Data.data.HEALTHCHECKS_SUPERUSER_PASSWORD }}\nSCRUTINY_INFLUXDB_PASSWORD={{ .Data.data.SCRUTINY_INFLUXDB_PASSWORD }}\nSCRUTINY_INFLUXDB_TOKEN={{ .Data.data.SCRUTINY_INFLUXDB_TOKEN }}\nTELEGRAM_BOT_TOKEN={{ .Data.data.TELEGRAM_BOT_TOKEN }}\n{{ end }}"
+            contents = "${renderedAt}{{ with secret \"secret/data/home/monitoring\" }}GRAFANA_SECRET_KEY={{ .Data.data.GRAFANA_SECRET_KEY }}\nHEALTHCHECKS_SECRET_KEY={{ .Data.data.HEALTHCHECKS_SECRET_KEY }}\nHEALTHCHECKS_SUPERUSER_PASSWORD={{ .Data.data.HEALTHCHECKS_SUPERUSER_PASSWORD }}\nSCRUTINY_INFLUXDB_PASSWORD={{ .Data.data.SCRUTINY_INFLUXDB_PASSWORD }}\nSCRUTINY_INFLUXDB_TOKEN={{ .Data.data.SCRUTINY_INFLUXDB_TOKEN }}\nTELEGRAM_BOT_TOKEN={{ .Data.data.TELEGRAM_BOT_TOKEN }}\n{{ end }}"
             destination = "/run/vault-agent/monitoring.env"
             perms = "0444"
           }
@@ -233,31 +237,31 @@
           # media-server). One render, layered into each consumer via vaultEnvStacks
           # (secret/home/shared-db). POSTGRES_USER stays config in the sops .env.
           template {
-            contents = "{{ with secret \"secret/data/home/shared-db\" }}POSTGRES_PASSWORD={{ .Data.data.POSTGRES_PASSWORD }}\nREDIS_PASSWORD={{ .Data.data.REDIS_PASSWORD }}\n{{ end }}"
+            contents = "${renderedAt}{{ with secret \"secret/data/home/shared-db\" }}POSTGRES_PASSWORD={{ .Data.data.POSTGRES_PASSWORD }}\nREDIS_PASSWORD={{ .Data.data.REDIS_PASSWORD }}\n{{ end }}"
             destination = "/run/vault-agent/shared-db.env"
             perms = "0444"
           }
           # P3.3 shared: arr API keys (media + homepage) and grafana admin creds
           # (monitoring + homepage). Each consumer lists these in vaultEnvStacks.
           template {
-            contents = "{{ with secret \"secret/data/home/shared-arr\" }}RADARR_API_KEY={{ .Data.data.RADARR_API_KEY }}\nSONARR_API_KEY={{ .Data.data.SONARR_API_KEY }}\nLIDARR_API_KEY={{ .Data.data.LIDARR_API_KEY }}\n{{ end }}"
+            contents = "${renderedAt}{{ with secret \"secret/data/home/shared-arr\" }}RADARR_API_KEY={{ .Data.data.RADARR_API_KEY }}\nSONARR_API_KEY={{ .Data.data.SONARR_API_KEY }}\nLIDARR_API_KEY={{ .Data.data.LIDARR_API_KEY }}\n{{ end }}"
             destination = "/run/vault-agent/shared-arr.env"
             perms = "0444"
           }
           template {
-            contents = "{{ with secret \"secret/data/home/shared-grafana\" }}GRAFANA_ADMIN_USER={{ .Data.data.GRAFANA_ADMIN_USER }}\nGRAFANA_ADMIN_PASSWORD={{ .Data.data.GRAFANA_ADMIN_PASSWORD }}\n{{ end }}"
+            contents = "${renderedAt}{{ with secret \"secret/data/home/shared-grafana\" }}GRAFANA_ADMIN_USER={{ .Data.data.GRAFANA_ADMIN_USER }}\nGRAFANA_ADMIN_PASSWORD={{ .Data.data.GRAFANA_ADMIN_PASSWORD }}\n{{ end }}"
             destination = "/run/vault-agent/shared-grafana.env"
             perms = "0444"
           }
           # P3.3 per-stack local secrets (batch 2). Each compose stack keeps its
           # interpolation; values move from the sops .env to these renders.
           template {
-            contents = "{{ with secret \"secret/data/home/media-server\" }}JELLYSTAT_JWT_SECRET={{ .Data.data.JELLYSTAT_JWT_SECRET }}\n{{ end }}"
+            contents = "${renderedAt}{{ with secret \"secret/data/home/media-server\" }}JELLYSTAT_JWT_SECRET={{ .Data.data.JELLYSTAT_JWT_SECRET }}\n{{ end }}"
             destination = "/run/vault-agent/media-server.env"
             perms = "0444"
           }
           template {
-            contents = "{{ with secret \"secret/data/home/tools\" }}SEARXNG_SECRET_KEY={{ .Data.data.SEARXNG_SECRET_KEY }}\n{{ end }}"
+            contents = "${renderedAt}{{ with secret \"secret/data/home/tools\" }}SEARXNG_SECRET_KEY={{ .Data.data.SEARXNG_SECRET_KEY }}\n{{ end }}"
             destination = "/run/vault-agent/tools.env"
             perms = "0440"
             exec {
@@ -265,17 +269,17 @@
             }
           }
           template {
-            contents = "{{ with secret \"secret/data/home/media\" }}NORDVPN_USER={{ .Data.data.NORDVPN_USER }}\nNORDVPN_PASSWORD={{ .Data.data.NORDVPN_PASSWORD }}\nQBITTORRENT_USER={{ .Data.data.QBITTORRENT_USER }}\nQBITTORRENT_PASSWORD={{ .Data.data.QBITTORRENT_PASSWORD }}\n{{ end }}"
+            contents = "${renderedAt}{{ with secret \"secret/data/home/media\" }}NORDVPN_USER={{ .Data.data.NORDVPN_USER }}\nNORDVPN_PASSWORD={{ .Data.data.NORDVPN_PASSWORD }}\nQBITTORRENT_USER={{ .Data.data.QBITTORRENT_USER }}\nQBITTORRENT_PASSWORD={{ .Data.data.QBITTORRENT_PASSWORD }}\n{{ end }}"
             destination = "/run/vault-agent/media.env"
             perms = "0444"
           }
           template {
-            contents = "{{ with secret \"secret/data/home/ai-serving\" }}LITELLM_SALT_KEY={{ .Data.data.LITELLM_SALT_KEY }}\nLANGFUSE_PUBLIC_KEY={{ .Data.data.LANGFUSE_PUBLIC_KEY }}\nLANGFUSE_SECRET_KEY={{ .Data.data.LANGFUSE_SECRET_KEY }}\nLANGFUSE_SALT={{ .Data.data.LANGFUSE_SALT }}\nLANGFUSE_INIT_USER_PASSWORD={{ .Data.data.LANGFUSE_INIT_USER_PASSWORD }}\nOPENCODE_GO_KEY={{ .Data.data.OPENCODE_GO_KEY }}\nUI_PASSWORD={{ .Data.data.UI_PASSWORD }}\nMINIO_ROOT_PASSWORD={{ .Data.data.MINIO_ROOT_PASSWORD }}\nCLICKHOUSE_PASSWORD={{ .Data.data.CLICKHOUSE_PASSWORD }}\n{{ end }}"
+            contents = "${renderedAt}{{ with secret \"secret/data/home/ai-serving\" }}LITELLM_SALT_KEY={{ .Data.data.LITELLM_SALT_KEY }}\nLANGFUSE_PUBLIC_KEY={{ .Data.data.LANGFUSE_PUBLIC_KEY }}\nLANGFUSE_SECRET_KEY={{ .Data.data.LANGFUSE_SECRET_KEY }}\nLANGFUSE_SALT={{ .Data.data.LANGFUSE_SALT }}\nLANGFUSE_INIT_USER_PASSWORD={{ .Data.data.LANGFUSE_INIT_USER_PASSWORD }}\nOPENCODE_GO_KEY={{ .Data.data.OPENCODE_GO_KEY }}\nUI_PASSWORD={{ .Data.data.UI_PASSWORD }}\nMINIO_ROOT_PASSWORD={{ .Data.data.MINIO_ROOT_PASSWORD }}\nCLICKHOUSE_PASSWORD={{ .Data.data.CLICKHOUSE_PASSWORD }}\n{{ end }}"
             destination = "/run/vault-agent/ai-serving.env"
             perms = "0444"
           }
           template {
-            contents = "{{ with secret \"secret/data/home/networking\" }}CLOUDFLARE_API_TOKEN={{ .Data.data.CLOUDFLARE_API_TOKEN }}\n{{ end }}"
+            contents = "${renderedAt}{{ with secret \"secret/data/home/networking\" }}CLOUDFLARE_API_TOKEN={{ .Data.data.CLOUDFLARE_API_TOKEN }}\n{{ end }}"
             destination = "/run/vault-agent/networking.env"
             perms = "0444"
           }
@@ -283,12 +287,12 @@
           # project-scoped robot beside the admin/database inputs without
           # exposing any of them to rootless Compose.
           template {
-            contents = "{{ with secret \"secret/data/home/harbor\" }}HARBOR_ADMIN_PASSWORD={{ .Data.data.HARBOR_ADMIN_PASSWORD }}\nHARBOR_DB_PASSWORD={{ .Data.data.HARBOR_DB_PASSWORD }}\nHARBOR_ROBOT_USER={{ .Data.data.HARBOR_ROBOT_USER }}\nHARBOR_ROBOT_SECRET={{ .Data.data.HARBOR_ROBOT_SECRET }}\n{{ end }}"
+            contents = "${renderedAt}{{ with secret \"secret/data/home/harbor\" }}HARBOR_ADMIN_PASSWORD={{ .Data.data.HARBOR_ADMIN_PASSWORD }}\nHARBOR_DB_PASSWORD={{ .Data.data.HARBOR_DB_PASSWORD }}\nHARBOR_ROBOT_USER={{ .Data.data.HARBOR_ROBOT_USER }}\nHARBOR_ROBOT_SECRET={{ .Data.data.HARBOR_ROBOT_SECRET }}\n{{ end }}"
             destination = "/run/vault-agent/harbor.env"
             perms = "0400"
           }
           template {
-            contents = "{{ with secret \"secret/data/home/ha-harness\" }}LITELLM_API_KEY={{ .Data.data.LITELLM_API_KEY }}\nHA_HARNESS_TOKEN={{ .Data.data.HA_HARNESS_TOKEN }}\n{{ end }}"
+            contents = "${renderedAt}{{ with secret \"secret/data/home/ha-harness\" }}LITELLM_API_KEY={{ .Data.data.LITELLM_API_KEY }}\nHA_HARNESS_TOKEN={{ .Data.data.HA_HARNESS_TOKEN }}\n{{ end }}"
             destination = "/run/vault-agent/ha-harness.env"
             perms = "0440"
             exec {

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -14,6 +14,7 @@ import unittest
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "modules/server/_secretspec-runtime-projection.py"
 ORCHESTRATION = ROOT / "modules/server/orchestration.nix"
+VAULT = ROOT / "modules/hosts/discovery/vault.nix"
 
 
 class RuntimeProjectionTest(unittest.TestCase):
@@ -129,6 +130,21 @@ class RuntimeProjectionTest(unittest.TestCase):
         self.assertIn("--source-config-name ${n}", source)
         self.assertIn("secretSpecRuntimeIgnoredSourceNames", source)
         self.assertIn("--ignored-source-name ${n}", source)
+
+    def test_vault_dotenv_renders_publish_a_freshness_witness(self):
+        source = VAULT.read_text()
+        self.assertIn('static_secret_render_interval = "5m"', source)
+        self.assertIn("renderedAt = ''# rendered_at={{ timestamp }}\\n'';", source)
+        dotenv_templates = [
+            block
+            for block in source.split("template {")[1:]
+            if 'destination = "/run/vault-agent/' in block
+            and '.env"' in block.split("template {", 1)[0]
+        ]
+        self.assertGreaterEqual(len(dotenv_templates), 12)
+        for block in dotenv_templates:
+            template = block.split("template {", 1)[0]
+            self.assertIn('contents = "${renderedAt}', template)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- explicitly re-evaluate static OpenBao templates every five minutes
- add a non-secret timestamp comment to dotenv renders so mtime witnesses successful evaluation
- preserve the existing 15-minute SecretSpec fail-closed freshness gate

## Verification
- `pytest -q tests/discovery-secret-contract/test_runtime_projection.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`

## Incident
A homepage restart failed because unchanged KV output retained an old mtime despite an active Vault Agent. The timestamp is a comment ignored by dotenv consumers and contains no secret material.