### PR TITLE
fix(secrets): accept render witness comments

### DIFF
--- a/justfile
+++ b/justfile
@@ -2342,7 +2342,7 @@ verify-tools-secret-render:
         exit 1
       fi
       sudo find /run/vault-agent/tools.env -mmin -15 -print -quit | grep -q .
-      test "$(sudo cut -d= -f1 /run/vault-agent/tools.env)" = SEARXNG_SECRET_KEY
+      test "$(sudo grep -v '^#' /run/vault-agent/tools.env | cut -d= -f1)" = SEARXNG_SECRET_KEY
       echo "tools_render=ready mode=0440 owner=root group=docker fresh=true"
     '
 
@@ -2361,7 +2361,7 @@ verify-ha-harness-secret-render:
         exit 1
       fi
       sudo find /run/vault-agent/ha-harness.env -mmin -15 -print -quit | grep -q .
-      actual="$(sudo cut -d= -f1 /run/vault-agent/ha-harness.env | sort -u)"
+      actual="$(sudo grep -v '^#' /run/vault-agent/ha-harness.env | cut -d= -f1 | sort -u)"
       expected="$(printf "HA_HARNESS_TOKEN\nLITELLM_API_KEY")"
       test "$actual" = "$expected"
       echo "ha_harness_render=ready mode=0440 owner=root group=docker fresh=true"

--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -172,5 +172,5 @@
     "user": "root"
   },
   "source": "modules/hosts/discovery/vault.nix",
-  "source_sha256": "1a93f305afc5555d94cc37cdc2d08b2d304a832252422e59b49eaa67336af1e2"
+  "source_sha256": "8ece31a6673c4c3761c819f643e88c54d3e3063ebff93b9d5fa779df19fc70b8"
 }

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -66,6 +66,7 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
         self.assertIn("sudo -u nobody head -c0 /run/vault-agent/tools.env", justfile)
         self.assertIn("sudo stat -c", justfile)
         self.assertIn("440 root docker", justfile)
+        self.assertGreaterEqual(justfile.count("grep -v '^#'"), 2)
 
     def test_ha_harness_render_has_value_free_live_verification_recipe(self):
         justfile = JUSTFILE.read_text()


### PR DESCRIPTION
## Summary
- ignore freshness comments in tools and ha-harness name checks
- refresh the generated value-free Vault owner contract
- add regression coverage for both verifier filters

## Verification
- live tools and ha-harness render checks pass
- `pytest -q tests/discovery-secret-contract/test_vault_surface.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`