### PR TITLE
feat(secrets): cut over media-server

### DIFF
--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -25,6 +25,9 @@ _: {
       secretSpecRuntimeProfiles.homepage = "homepage";
       secretSpecRuntimeSourceConfigNames.homepage = ["GRAFANA_ADMIN_USER"];
       secretSpecRuntimeHealthContainers.homepage = "homepage";
+      secretSpecRuntimeProfiles."media-server" = "media-server";
+      secretSpecRuntimeIgnoredSourceNames."media-server" = ["REDIS_PASSWORD"];
+      secretSpecRuntimeHealthContainers."media-server" = "jellystat";
       stacks = [
         # shared.yml has no services on discovery (alloy/syncthing/etc run natively)
         "infra" # postgres, redis, vault, adguard

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -15,6 +15,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "modules/server/_secretspec-runtime-projection.py"
 ORCHESTRATION = ROOT / "modules/server/orchestration.nix"
 VAULT = ROOT / "modules/hosts/discovery/vault.nix"
+COMPOSE = ROOT / "modules/hosts/discovery/compose.nix"
 
 
 class RuntimeProjectionTest(unittest.TestCase):
@@ -145,6 +146,18 @@ class RuntimeProjectionTest(unittest.TestCase):
         for block in dotenv_templates:
             template = block.split("template {", 1)[0]
             self.assertIn('contents = "${renderedAt}', template)
+
+    def test_media_server_uses_exact_profile_boundary(self):
+        source = COMPOSE.read_text()
+        self.assertIn('secretSpecRuntimeProfiles."media-server" = "media-server";', source)
+        self.assertIn(
+            'secretSpecRuntimeIgnoredSourceNames."media-server" = ["REDIS_PASSWORD"];',
+            source,
+        )
+        self.assertIn(
+            'secretSpecRuntimeHealthContainers."media-server" = "jellystat";',
+            source,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enable the media-server SecretSpec runtime profile
- accept but emit nowhere the unused shared-db REDIS_PASSWORD
- require Jellystat health after Compose startup

## Verification
- profile wiring regression passed RED then GREEN
- 10 projection tests pass
- `just lint`
- `just fmt-check`
- `just dry discovery`

Critical profiles remain unchanged.