### PR TITLE
feat(secrets): cut over monitoring runtime

### DIFF
--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -28,6 +28,9 @@ _: {
       secretSpecRuntimeProfiles."media-server" = "media-server";
       secretSpecRuntimeIgnoredSourceNames."media-server" = ["REDIS_PASSWORD"];
       secretSpecRuntimeHealthContainers."media-server" = ["jellystat"];
+      secretSpecRuntimeProfiles.monitoring = "monitoring";
+      secretSpecRuntimeSourceConfigNames.monitoring = ["GRAFANA_ADMIN_USER"];
+      secretSpecRuntimeHealthContainers.monitoring = ["grafana" "healthchecks" "scrutiny-influxdb" "scrutiny"];
       stacks = [
         # shared.yml has no services on discovery (alloy/syncthing/etc run natively)
         "infra" # postgres, redis, vault, adguard

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -155,6 +155,18 @@ class RuntimeProjectionTest(unittest.TestCase):
             source,
         )
 
+    def test_monitoring_gates_all_secret_consumers(self):
+        source = COMPOSE.read_text()
+        self.assertIn('secretSpecRuntimeProfiles.monitoring = "monitoring";', source)
+        self.assertIn(
+            'secretSpecRuntimeSourceConfigNames.monitoring = ["GRAFANA_ADMIN_USER"];',
+            source,
+        )
+        self.assertIn(
+            'secretSpecRuntimeHealthContainers.monitoring = ["grafana" "healthchecks" "scrutiny-influxdb" "scrutiny"];',
+            source,
+        )
+
     def test_runtime_health_gate_accepts_all_secret_consumers(self):
         orchestration = ORCHESTRATION.read_text()
         compose = COMPOSE.read_text()


### PR DESCRIPTION
## Summary
- route monitoring through its exact SecretSpec profile
- preserve GRAFANA_ADMIN_USER as authoritative config
- gate startup on grafana, healthchecks, scrutiny-influxdb, and scrutiny health

## Verification
- runtime projection tests pass
- just lint
- just fmt-check
- just dry discovery