### PR TITLE
feat(secrets): support sops runtime sources

### DIFF
--- a/modules/server/_secretspec-runtime-projection.py
+++ b/modules/server/_secretspec-runtime-projection.py
@@ -103,7 +103,8 @@ def main() -> None:
     parser.add_argument("--manifest", type=pathlib.Path, required=True)
     parser.add_argument("--profile", required=True)
     parser.add_argument("--legacy-env", type=pathlib.Path, required=True)
-    parser.add_argument("--source", type=pathlib.Path, action="append", required=True)
+    parser.add_argument("--source", type=pathlib.Path, action="append", default=[])
+    parser.add_argument("--legacy-secret-name", action="append", default=[])
     parser.add_argument("--source-config-name", action="append", default=[])
     parser.add_argument("--ignored-source-name", action="append", default=[])
     parser.add_argument("--output-dir", type=pathlib.Path, required=True)
@@ -119,6 +120,9 @@ def main() -> None:
         expected_names = set(profile)
         if any(not NAME.fullmatch(name) for name in expected_names):
             raise ProjectionError("invalid SecretSpec profile name")
+        legacy_secret_names = set(args.legacy_secret_name)
+        if len(legacy_secret_names) != len(args.legacy_secret_name) or not legacy_secret_names <= expected_names:
+            raise ProjectionError("invalid, duplicate, or out-of-profile legacy secret name")
         source_config_names = set(args.source_config_name)
         if len(source_config_names) != len(args.source_config_name) or any(
             not NAME.fullmatch(name) for name in source_config_names
@@ -151,15 +155,6 @@ def main() -> None:
                     raise ProjectionError(f"conflicting duplicate dotenv name: {name}")
                 merged[name] = row
 
-        actual_names = set(merged)
-        if actual_names != allowed_names:
-            missing = sorted(allowed_names - actual_names)
-            extra = sorted(actual_names - allowed_names)
-            raise ProjectionError(
-                f"provider name closure differs (missing={','.join(missing) or '-'}; "
-                f"extra={','.join(extra) or '-'})"
-            )
-
         legacy_lines = args.legacy_env.read_text().splitlines()
         config_lines: list[str] = []
         for number, raw in enumerate(legacy_lines, 1):
@@ -170,11 +165,26 @@ def main() -> None:
             declaration = line[7:].lstrip() if line.startswith("export ") else line
             if "=" not in declaration:
                 raise ProjectionError(f"malformed legacy dotenv declaration: {args.legacy_env}:{number}")
-            name = declaration.split("=", 1)[0]
+            name, value = declaration.split("=", 1)
             if not NAME.fullmatch(name):
                 raise ProjectionError(f"invalid legacy dotenv name: {args.legacy_env}:{number}")
+            if name in legacy_secret_names:
+                if not value.strip():
+                    raise ProjectionError(f"empty legacy secret: {args.legacy_env}:{number}")
+                if name in merged and merged[name] != declaration:
+                    raise ProjectionError(f"conflicting duplicate dotenv name: {name}")
+                merged[name] = declaration
             if name not in allowed_names:
                 config_lines.append(raw)
+
+        actual_names = set(merged)
+        if actual_names != allowed_names:
+            missing = sorted(allowed_names - actual_names)
+            extra = sorted(actual_names - allowed_names)
+            raise ProjectionError(
+                f"provider name closure differs (missing={','.join(missing) or '-'}; "
+                f"extra={','.join(extra) or '-'})"
+            )
 
         config_lines.extend(merged[name] for name in sorted(source_config_names))
 

--- a/modules/server/orchestration.nix
+++ b/modules/server/orchestration.nix
@@ -97,6 +97,12 @@ in {
         '';
       };
 
+      secretSpecRuntimeLegacySecretNames = lib.mkOption {
+        type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+        default = {};
+        description = "Per-stack secret names sourced from the sops-decrypted legacy dotenv.";
+      };
+
       secretSpecRuntimeMaxAgeSeconds = lib.mkOption {
         type = lib.types.ints.positive;
         default = 900;
@@ -156,6 +162,7 @@ in {
         secretSpecHealthContainers = cfg.secretSpecRuntimeHealthContainers.${name} or [];
         secretSpecSourceConfigNames = cfg.secretSpecRuntimeSourceConfigNames.${name} or [];
         secretSpecIgnoredSourceNames = cfg.secretSpecRuntimeIgnoredSourceNames.${name} or [];
+        secretSpecLegacySecretNames = cfg.secretSpecRuntimeLegacySecretNames.${name} or [];
         vaultBasenames = cfg.vaultEnvStacks.${name} or [];
         vaultEnvFlags =
           lib.concatMapStrings (b: " --env-file /run/vault-agent/${b}.env")
@@ -171,11 +178,12 @@ in {
         projectionSourceFlags = lib.concatMapStrings (b: " --source /run/vault-agent/${b}.env") vaultBasenames;
         projectionConfigFlags = lib.concatMapStrings (n: " --source-config-name ${n}") secretSpecSourceConfigNames;
         projectionIgnoredFlags = lib.concatMapStrings (n: " --ignored-source-name ${n}") secretSpecIgnoredSourceNames;
+        projectionLegacyFlags = lib.concatMapStrings (n: " --legacy-secret-name ${n}") secretSpecLegacySecretNames;
         secretSpecPrefix = lib.optionalString (secretSpecProfile != null) "${pkgs.secretspec}/bin/secretspec run --file ${cfg.composeDir}/secretspec.toml --profile ${secretSpecProfile} --provider dotenv:${runtimeProvider} --reason discovery-${name}-production-runtime -- ";
         legacyStop = "/run/current-system/sw/bin/docker-compose --project-name ${name} --env-file ${composeEnv}${vaultEnvFlags} -f ${cfg.composeDir}/${name}.yml stop";
         secretSpecPreflight = [
           "${pkgs.systemd}/bin/systemctl is-active vault-agent.service"
-          "${secretSpecRuntimeProjection}/bin/secretspec-runtime-projection --manifest ${cfg.composeDir}/secretspec.toml --profile ${secretSpecProfile} --legacy-env ${cfg.composeDir}/.env${projectionSourceFlags}${projectionConfigFlags}${projectionIgnoredFlags} --output-dir ${runtimeOutputDir} --max-age-seconds ${toString cfg.secretSpecRuntimeMaxAgeSeconds}"
+          "${secretSpecRuntimeProjection}/bin/secretspec-runtime-projection --manifest ${cfg.composeDir}/secretspec.toml --profile ${secretSpecProfile} --legacy-env ${cfg.composeDir}/.env${projectionSourceFlags}${projectionConfigFlags}${projectionIgnoredFlags}${projectionLegacyFlags} --output-dir ${runtimeOutputDir} --max-age-seconds ${toString cfg.secretSpecRuntimeMaxAgeSeconds}"
         ];
         secretSpecHealthGate =
           if secretSpecHealthContainers == []

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -34,7 +34,7 @@ class RuntimeProjectionTest(unittest.TestCase):
 
     def run_projection(
         self, *sources: str, max_age: int = 900, source_config_names=(),
-        ignored_source_names=(),
+        ignored_source_names=(), legacy_secret_names=(),
     ):
         command = [
             "python3", str(SCRIPT), "--manifest", str(self.root / "secretspec.toml"),
@@ -48,6 +48,8 @@ class RuntimeProjectionTest(unittest.TestCase):
             command.extend(["--source-config-name", name])
         for name in ignored_source_names:
             command.extend(["--ignored-source-name", name])
+        for name in legacy_secret_names:
+            command.extend(["--legacy-secret-name", name])
         return subprocess.run(command, text=True, capture_output=True, check=False)
 
     def test_merges_exact_provider_and_removes_secrets_from_compose_env(self):
@@ -105,6 +107,13 @@ class RuntimeProjectionTest(unittest.TestCase):
         self.assertNotIn("REDIS_PASSWORD", (current / "config.env").read_text())
         self.assertNotIn("ignored-value", result.stdout + result.stderr)
 
+    def test_can_project_sops_decrypted_secrets_from_legacy_env(self):
+        result = self.run_projection(legacy_secret_names=("A", "B"))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        current = self.root / "runtime/current"
+        self.assertEqual((current / "provider.env").read_text(), "A=legacy-a\nB=legacy-b\n")
+        self.assertEqual((current / "config.env").read_text(), "# config\nPORT=8080\n")
+
     def test_empty_malformed_and_stale_inputs_fail_closed(self):
         for content in ("A=\nB=sentinel-b\n", "A\nB=sentinel-b\n"):
             (self.root / "one.env").write_text(content)
@@ -131,6 +140,8 @@ class RuntimeProjectionTest(unittest.TestCase):
         self.assertIn("--source-config-name ${n}", source)
         self.assertIn("secretSpecRuntimeIgnoredSourceNames", source)
         self.assertIn("--ignored-source-name ${n}", source)
+        self.assertIn("secretSpecRuntimeLegacySecretNames", source)
+        self.assertIn("--legacy-secret-name ${n}", source)
 
     def test_vault_dotenv_renders_publish_a_freshness_witness(self):
         source = VAULT.read_text()


### PR DESCRIPTION
## Summary
- allow approved SecretSpec profiles to source required secrets from the sops-decrypted legacy dotenv
- preserve exact provider closure and remove projected secrets from Compose config
- leave Vault-backed behavior unchanged

## Verification
- 13 runtime projection tests pass
- just lint
- just fmt-check
- just dry discovery