### PR TITLE
fix(kindle): ignore unrelated release commits

### DIFF
--- a/modules/hosts/discovery/_kindle-release-agent.py
+++ b/modules/hosts/discovery/_kindle-release-agent.py
@@ -678,11 +678,17 @@ def observe_candidate(runner, previous_commit):
     if commit == previous_commit:
         return None
     runner.run(git + ["merge-base", "--is-ancestor", previous_commit, commit])
-    changed_paths = runner.run(
-        git + ["diff", "--name-only", f"{previous_commit}..{commit}"]
+    candidates = runner.run(
+        git + ["rev-list", "--reverse", f"{previous_commit}..{commit}", "--", COMPOSE_PATH]
     ).splitlines()
-    compose_text = runner.run(git + ["show", f"{commit}:{COMPOSE_PATH}"])
-    return validate_candidate(commit, changed_paths, compose_text)
+    if not candidates:
+        return None
+    candidate = candidates[0]
+    changed_paths = runner.run(
+        git + ["diff-tree", "--no-commit-id", "--name-only", "-r", candidate]
+    ).splitlines()
+    compose_text = runner.run(git + ["show", f"{candidate}:{COMPOSE_PATH}"])
+    return validate_candidate(candidate, changed_paths, compose_text)
 
 
 def observe_live_release(runner):

--- a/tests/kindle-release-agent/test_agent.py
+++ b/tests/kindle-release-agent/test_agent.py
@@ -1050,6 +1050,7 @@ class ObservationContract(unittest.TestCase):
                 "",
                 self.target + "\n",
                 "",
+                self.target + "\n",
                 self.agent.COMPOSE_PATH + "\n",
                 self.compose,
             ]
@@ -1084,9 +1085,19 @@ class ObservationContract(unittest.TestCase):
                 ],
                 [
                     *git,
-                    "diff",
-                    "--name-only",
+                    "rev-list",
+                    "--reverse",
                     f"{self.previous}..{self.target}",
+                    "--",
+                    self.agent.COMPOSE_PATH,
+                ],
+                [
+                    *git,
+                    "diff-tree",
+                    "--no-commit-id",
+                    "--name-only",
+                    "-r",
+                    self.target,
                 ],
                 [
                     *git,
@@ -1103,12 +1114,17 @@ class ObservationContract(unittest.TestCase):
                 "",
                 self.target,
                 "",
+                self.target,
                 self.agent.COMPOSE_PATH + "\nother.yml\n",
                 self.compose,
             ]
         )
         with self.assertRaises(ValueError):
             self.agent.observe_candidate(runner, self.previous)
+
+    def test_observation_ignores_advances_without_compose_change(self):
+        runner = self.Runner(["", self.target, "", ""])
+        self.assertIsNone(self.agent.observe_candidate(runner, self.previous))
 
     def test_observation_returns_none_when_main_has_not_advanced(self):
         runner = self.Runner(["", self.previous + "\n"])


### PR DESCRIPTION
## Summary
- discover the next commit that actually touched Kindle Compose
- retain strict single-path candidate validation
- ignore unrelated Servarr advances instead of failing the timer and Nix activation

## Verification
- 96 release-agent tests pass
- just lint
- just fmt-check
- just dry discovery