### PR TITLE
feat(secrets): cut over noncritical runtime wave

### DIFF
--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -31,6 +31,24 @@ _: {
       secretSpecRuntimeProfiles.monitoring = "monitoring";
       secretSpecRuntimeSourceConfigNames.monitoring = ["GRAFANA_ADMIN_USER"];
       secretSpecRuntimeHealthContainers.monitoring = ["grafana" "healthchecks" "scrutiny-influxdb" "scrutiny"];
+      secretSpecRuntimeProfiles.media = "media";
+      secretSpecRuntimeSourceConfigNames.media = ["NORDVPN_USER" "QBITTORRENT_USER"];
+      secretSpecRuntimeHealthContainers.media = ["gluetun" "unpackerr" "decluttarr"];
+      secretSpecRuntimeProfiles.plex = "plex";
+      secretSpecRuntimeLegacySecretNames.plex = ["PLEX_CLAIM"];
+      secretSpecRuntimeHealthContainers.plex = ["plex"];
+      secretSpecRuntimeProfiles."kindle-dash" = "kindle-dash";
+      secretSpecRuntimeLegacySecretNames."kindle-dash" = [
+        "KINDLE_DASH_CLAUDE_REFRESH_TOKEN"
+        "KINDLE_DASH_CODEX_REFRESH_TOKEN"
+        "KINDLE_DASH_HA_TOKEN"
+        "KINDLE_DASH_OPENCODE_AUTH_COOKIE"
+      ];
+      secretSpecRuntimeHealthContainers."kindle-dash" = ["kindle-dash"];
+      secretSpecRuntimeProfiles."ai-serving" = "ai-serving";
+      secretSpecRuntimeSourceConfigNames."ai-serving" = ["LANGFUSE_PUBLIC_KEY" "LANGFUSE_SALT"];
+      secretSpecRuntimeLegacySecretNames."ai-serving" = ["LITELLM_MASTER_KEY" "OPENCODE_ZEN_KEY"];
+      secretSpecRuntimeHealthContainers."ai-serving" = ["litellm" "langfuse-clickhouse" "langfuse-web" "langfuse-worker"];
       stacks = [
         # shared.yml has no services on discovery (alloy/syncthing/etc run natively)
         "infra" # postgres, redis, vault, adguard

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -173,6 +173,26 @@ class RuntimeProjectionTest(unittest.TestCase):
             'secretSpecRuntimeSourceConfigNames.monitoring = ["GRAFANA_ADMIN_USER"];',
             source,
         )
+
+    def test_remaining_noncritical_profiles_cut_over_as_one_wave(self):
+        source = COMPOSE.read_text()
+        expected = [
+            'secretSpecRuntimeProfiles.media = "media";',
+            'secretSpecRuntimeSourceConfigNames.media = ["NORDVPN_USER" "QBITTORRENT_USER"];',
+            'secretSpecRuntimeHealthContainers.media = ["gluetun" "unpackerr" "decluttarr"];',
+            'secretSpecRuntimeProfiles.plex = "plex";',
+            'secretSpecRuntimeLegacySecretNames.plex = ["PLEX_CLAIM"];',
+            'secretSpecRuntimeHealthContainers.plex = ["plex"];',
+            'secretSpecRuntimeProfiles."kindle-dash" = "kindle-dash";',
+            'secretSpecRuntimeLegacySecretNames."kindle-dash" = [',
+            'secretSpecRuntimeHealthContainers."kindle-dash" = ["kindle-dash"];',
+            'secretSpecRuntimeProfiles."ai-serving" = "ai-serving";',
+            'secretSpecRuntimeSourceConfigNames."ai-serving" = ["LANGFUSE_PUBLIC_KEY" "LANGFUSE_SALT"];',
+            'secretSpecRuntimeLegacySecretNames."ai-serving" = ["LITELLM_MASTER_KEY" "OPENCODE_ZEN_KEY"];',
+            'secretSpecRuntimeHealthContainers."ai-serving" = ["litellm" "langfuse-clickhouse" "langfuse-web" "langfuse-worker"];',
+        ]
+        for declaration in expected:
+            self.assertIn(declaration, source)
         self.assertIn(
             'secretSpecRuntimeHealthContainers.monitoring = ["grafana" "healthchecks" "scrutiny-influxdb" "scrutiny"];',
             source,


### PR DESCRIPTION
## Summary
- cut over media, plex, kindle-dash, and ai-serving together
- use exact Vault, SOPS, and mixed-provider boundaries
- gate every secret-consuming path on targeted container health
- leave infra, networking, and tunneling unchanged

## Verification
- 14 runtime projection tests pass
- just lint
- just fmt-check
- just dry discovery