### PR TITLE
fix(secrets): decouple SOPS profiles from Vault

### DIFF
--- a/docs/guides/break-glass.md
+++ b/docs/guides/break-glass.md
@@ -40,7 +40,7 @@ OpenBao commands. If this guide and a recipe disagree, the recipe wins.
 | --- | --- | --- |
 | A deployment loses connectivity | Let deploy-rs magic rollback finish. Re-evaluate the intended revision with `just dry <host>` before another `just switch-<host>`. | Deployment confirmed; SSH/tailnet reachable; affected services checked. |
 | One Servarr stack fails | `just diagnose-stack <host> <stack>`. Fix in the Servarr repo, commit and push, then `just pull-servarr <host>` and `just kick-stack <host> <stack>`. | Unit active; intended container health/integration probe passes. |
-| SecretSpec stack fails before Compose | Check the unit with `just diagnose-stack`. For Discovery tools, run `just verify-tools-secret-render`. If the render is stale after an expected provider update, use `just refresh-vault-agent discovery`, verify again, then recreate only the affected stack. | Provider active; render metadata is least-privilege and fresh; SecretSpec preflight and targeted health gate pass. |
+| SecretSpec stack fails before Compose | Check the unit with `just diagnose-stack`, then identify the profile's declared sources in `secretspec.toml`. For Vault-backed names, verify or refresh Vault Agent with the documented recipe. For SOPS-backed names, restore the encrypted Servarr source through Git and `just pull-servarr <host>`. Mixed profiles require both providers. Recreate only the affected stack. | Every declared provider is healthy; SecretSpec preflight and targeted health gate pass. |
 | SecretSpec regression after a cutover | Revert the versioned desktop-nixos cutover, run `just dry discovery`, deploy with `just switch-discovery`, then `just kick-stack discovery <stack>`. Keep Vault Agent and its render intact. | Direct-Compose rollback unit active; service health matches pre-cutover evidence. |
 | OpenBao is sealed | Follow [Vault disaster recovery — Scenario A](../reference/vault-disaster-recovery.md#scenario-a--node-sealed-reboot--restart). Do not initialize a new cluster. | `Initialized=true`, `Sealed=false`; consumers re-sync. |
 | OpenBao data is corrupt or missing | Follow [Vault disaster recovery — Scenario B](../reference/vault-disaster-recovery.md#scenario-b--data-corrupt--lost-host-intact). Snapshot restore is destructive and needs explicit approval. | Known-path read succeeds without logging its value; fresh backup succeeds. |
@@ -52,7 +52,7 @@ OpenBao commands. If this guide and a recipe disagree, the recipe wins.
 
 ## SecretSpec and Vault Agent triage
 
-The runtime chain is:
+The Vault-backed runtime chain is:
 
 ```text
 OpenBao authority -> Vault Agent render -> SecretSpec process environment
@@ -64,6 +64,13 @@ a failed SecretSpec preflight is an execution-boundary problem; a healthy start
 followed by an unhealthy target is an application problem. Do not bypass
 SecretSpec by adding the provider file directly to Compose unless executing the
 reviewed rollback revision.
+
+SOPS-only profiles do not depend on Vault Agent. Recover their encrypted source
+through the Servarr Git delivery flow, then recreate the affected stack. Mixed
+profiles need both the SOPS source and Vault Agent render healthy; restoring one
+provider does not make the profile complete. Use the profile declarations in
+`secretspec.toml` as the source-closure authority instead of guessing from the
+stack name.
 
 For the Discovery tools pilot, expected metadata is `0440 root:docker`, the
 declared name set contains only `SEARXNG_SECRET_KEY`, and SearXNG is the targeted
@@ -87,4 +94,3 @@ health gate. Never inspect or compare the value in terminal output.
 - [Frozen PID1 recovery](../reference/recovery-frozen-pid1.md)
 - [Vault backup implementation](../implemented/2026-06-29-vault-backup-plan.md)
 - [Offsite crown-jewel recovery](../implemented/2026-06-30-offsite-dr-crown-jewels.md)
-

--- a/modules/server/orchestration.nix
+++ b/modules/server/orchestration.nix
@@ -181,10 +181,13 @@ in {
         projectionLegacyFlags = lib.concatMapStrings (n: " --legacy-secret-name ${n}") secretSpecLegacySecretNames;
         secretSpecPrefix = lib.optionalString (secretSpecProfile != null) "${pkgs.secretspec}/bin/secretspec run --file ${cfg.composeDir}/secretspec.toml --profile ${secretSpecProfile} --provider dotenv:${runtimeProvider} --reason discovery-${name}-production-runtime -- ";
         legacyStop = "/run/current-system/sw/bin/docker-compose --project-name ${name} --env-file ${composeEnv}${vaultEnvFlags} -f ${cfg.composeDir}/${name}.yml stop";
-        secretSpecPreflight = [
-          "${pkgs.systemd}/bin/systemctl is-active vault-agent.service"
-          "${secretSpecRuntimeProjection}/bin/secretspec-runtime-projection --manifest ${cfg.composeDir}/secretspec.toml --profile ${secretSpecProfile} --legacy-env ${cfg.composeDir}/.env${projectionSourceFlags}${projectionConfigFlags}${projectionIgnoredFlags}${projectionLegacyFlags} --output-dir ${runtimeOutputDir} --max-age-seconds ${toString cfg.secretSpecRuntimeMaxAgeSeconds}"
-        ];
+        secretSpecPreflight =
+          lib.optionals (vaultBasenames != []) [
+            "${pkgs.systemd}/bin/systemctl is-active vault-agent.service"
+          ]
+          ++ [
+            "${secretSpecRuntimeProjection}/bin/secretspec-runtime-projection --manifest ${cfg.composeDir}/secretspec.toml --profile ${secretSpecProfile} --legacy-env ${cfg.composeDir}/.env${projectionSourceFlags}${projectionConfigFlags}${projectionIgnoredFlags}${projectionLegacyFlags} --output-dir ${runtimeOutputDir} --max-age-seconds ${toString cfg.secretSpecRuntimeMaxAgeSeconds}"
+          ];
         secretSpecHealthGate =
           if secretSpecHealthContainers == []
           then null

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -142,6 +142,7 @@ class RuntimeProjectionTest(unittest.TestCase):
         self.assertIn("--ignored-source-name ${n}", source)
         self.assertIn("secretSpecRuntimeLegacySecretNames", source)
         self.assertIn("--legacy-secret-name ${n}", source)
+        self.assertIn("lib.optionals (vaultBasenames != [])", source)
 
     def test_vault_dotenv_renders_publish_a_freshness_witness(self):
         source = VAULT.read_text()


### PR DESCRIPTION
## Summary
- gate Vault Agent preflight only for profiles with Vault-backed names
- lock behavior with the Discovery SecretSpec contract test
- distinguish SOPS-only, Vault-only, and mixed recovery in break-glass guidance

## Verification
- `python -m unittest tests/discovery-secret-contract/test_runtime_projection.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`
- `just docs-check` (blocked by pre-existing broken `klipper-biqu` sister-repo link in `docs/implemented/2026-06-16-printer-nixos-host.md`; no new guide link failures)