### PR TITLE
feat(secrets): cut over tunneling runtime

### DIFF
--- a/justfile
+++ b/justfile
@@ -2346,6 +2346,26 @@ verify-tools-secret-render:
       echo "tools_render=ready mode=0440 owner=root group=docker fresh=true"
     '
 
+# Prove the critical tunneling render is fresh and least-privilege without printing it.
+verify-tunneling-secret-render:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP="$(just _host-ip discovery)"
+    ssh -p 2222 erik@"$IP" '
+      set -euo pipefail
+      sudo systemctl is-active vault-agent.service
+      test "$(sudo stat -c '"'"'%a %U %G'"'"' /run/vault-agent/tunneling.env)" = "440 root docker"
+      sudo -u erik head -c0 /run/vault-agent/tunneling.env
+      if sudo -u nobody head -c0 /run/vault-agent/tunneling.env 2>/dev/null; then
+        echo "nobody unexpectedly read tunneling render" >&2
+        exit 1
+      fi
+      sudo find /run/vault-agent/tunneling.env -mmin -15 -print -quit | grep -q .
+      actual="$(sudo grep -v '^#' /run/vault-agent/tunneling.env | cut -d= -f1)"
+      test "$actual" = CLOUDFLARE_TUNNEL_TOKEN
+      echo "tunneling_render=ready mode=0440 owner=root group=docker fresh=true"
+    '
+
 # Prove the DS8 ha-harness render is fresh and least-privilege without printing it.
 verify-ha-harness-secret-render:
     #!/usr/bin/env bash

--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -20,6 +20,8 @@ _: {
       };
       secretSpecRuntimeProfiles.tools = "tools";
       secretSpecRuntimeHealthContainers.tools = ["searxng"];
+      secretSpecRuntimeProfiles.tunneling = "tunneling";
+      secretSpecRuntimeHealthContainers.tunneling = ["cloudflared"];
       secretSpecRuntimeProfiles.ha-harness = "ha-harness";
       secretSpecRuntimeHealthContainers.ha-harness = ["ha-harness"];
       secretSpecRuntimeProfiles.homepage = "homepage";

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -16,6 +16,7 @@ SCRIPT = ROOT / "modules/server/_secretspec-runtime-projection.py"
 ORCHESTRATION = ROOT / "modules/server/orchestration.nix"
 VAULT = ROOT / "modules/hosts/discovery/vault.nix"
 COMPOSE = ROOT / "modules/hosts/discovery/compose.nix"
+JUSTFILE = ROOT / "justfile"
 
 
 class RuntimeProjectionTest(unittest.TestCase):
@@ -213,6 +214,17 @@ class RuntimeProjectionTest(unittest.TestCase):
             'secretSpecRuntimeHealthContainers."media-server" = ["jellystat"];',
             compose,
         )
+
+    def test_tunneling_cutover_has_exact_gate_and_value_free_render_check(self):
+        compose = COMPOSE.read_text()
+        justfile = JUSTFILE.read_text()
+        self.assertIn('secretSpecRuntimeProfiles.tunneling = "tunneling";', compose)
+        self.assertIn(
+            'secretSpecRuntimeHealthContainers.tunneling = ["cloudflared"];',
+            compose,
+        )
+        self.assertIn("verify-tunneling-secret-render:", justfile)
+        self.assertIn('test "$actual" = CLOUDFLARE_TUNNEL_TOKEN', justfile)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- authorize the existing exact `tunneling` SecretSpec profile
- gate startup on `cloudflared` health
- add a value-free least-privilege/freshness check for the Vault Agent render

## Verification
- `python -m unittest tests/discovery-secret-contract/test_runtime_projection.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`

Critical scope: tunneling only. Networking and infra remain excluded.