### PR TITLE
fix(secrets): restrict tunneling render access

### DIFF
--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -58,7 +58,7 @@
       "names": [
         "CLOUDFLARE_TUNNEL_TOKEN"
       ],
-      "perms": "0444"
+      "perms": "0440"
     },
     {
       "destination": "/run/vault-agent/monitoring.env",

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -218,12 +218,14 @@
           # --env-file for podman-compose-tunneling (orchestration.nix
           # vaultEnvStacks). cloudflared keeps its CLOUDFLARE_TUNNEL_TOKEN
           # interpolation; the value comes from OpenBao (secret/home/tunneling)
-          # instead of the sops .env. 0444 so the rootless-compose user reads it
-          # (matches discord.env; /run is tmpfs).
+          # instead of the sops .env. Restrict the render to the compose user.
           template {
             contents = "${renderedAt}CLOUDFLARE_TUNNEL_TOKEN={{ with secret \"secret/data/home/tunneling\" }}{{ .Data.data.CLOUDFLARE_TUNNEL_TOKEN }}{{ end }}\n"
             destination = "/run/vault-agent/tunneling.env"
-            perms = "0444"
+            perms = "0440"
+            exec {
+              command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/tunneling.env"]
+            }
           }
           # P3.3: monitoring stack-local secrets (grafana/healthchecks/scrutiny).
           # GRAFANA_ADMIN_{USER,PASSWORD} are shared with homepage → in the

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import pathlib
 import subprocess
@@ -218,6 +219,8 @@ class RuntimeProjectionTest(unittest.TestCase):
     def test_tunneling_cutover_has_exact_gate_and_value_free_render_check(self):
         compose = COMPOSE.read_text()
         justfile = JUSTFILE.read_text()
+        vault = VAULT.read_text()
+        contract = json.loads((ROOT / "modules/hosts/discovery/vault-env-contract.json").read_text())
         self.assertIn('secretSpecRuntimeProfiles.tunneling = "tunneling";', compose)
         self.assertIn(
             'secretSpecRuntimeHealthContainers.tunneling = ["cloudflared"];',
@@ -225,6 +228,9 @@ class RuntimeProjectionTest(unittest.TestCase):
         )
         self.assertIn("verify-tunneling-secret-render:", justfile)
         self.assertIn('test "$actual" = CLOUDFLARE_TUNNEL_TOKEN', justfile)
+        self.assertIn('["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/tunneling.env"]', vault)
+        tunneling = next(row for row in contract["renders"] if row["destination"].endswith("/tunneling.env"))
+        self.assertEqual(tunneling["perms"], "0440")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- change the tunneling Vault Agent render from world-readable `0444` to `0440 root:docker`
- keep the value-free pre-cutover verifier aligned with the rendered contract
- lock the permission and group assignment in the SecretSpec contract test

## Verification
- `python -m unittest tests/discovery-secret-contract/test_runtime_projection.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`

Found by the live pre-cutover gate. No tunneling restart or SecretSpec deployment has occurred.