### PR TITLE
feat(secrets): cut over networking runtime

### DIFF
--- a/justfile
+++ b/justfile
@@ -2366,6 +2366,26 @@ verify-tunneling-secret-render:
       echo "tunneling_render=ready mode=0440 owner=root group=docker fresh=true"
     '
 
+# Prove the critical networking render is fresh and least-privilege without printing it.
+verify-networking-secret-render:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP="$(just _host-ip discovery)"
+    ssh -p 2222 erik@"$IP" '
+      set -euo pipefail
+      sudo systemctl is-active vault-agent.service
+      test "$(sudo stat -c '"'"'%a %U %G'"'"' /run/vault-agent/networking.env)" = "440 root docker"
+      sudo -u erik head -c0 /run/vault-agent/networking.env
+      if sudo -u nobody head -c0 /run/vault-agent/networking.env 2>/dev/null; then
+        echo "nobody unexpectedly read networking render" >&2
+        exit 1
+      fi
+      sudo find /run/vault-agent/networking.env -mmin -15 -print -quit | grep -q .
+      actual="$(sudo grep -v '^#' /run/vault-agent/networking.env | cut -d= -f1)"
+      test "$actual" = CLOUDFLARE_API_TOKEN
+      echo "networking_render=ready mode=0440 owner=root group=docker fresh=true"
+    '
+
 # Prove the DS8 ha-harness render is fresh and least-privilege without printing it.
 verify-ha-harness-secret-render:
     #!/usr/bin/env bash

--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -22,6 +22,9 @@ _: {
       secretSpecRuntimeHealthContainers.tools = ["searxng"];
       secretSpecRuntimeProfiles.tunneling = "tunneling";
       secretSpecRuntimeHealthContainers.tunneling = ["cloudflared"];
+      secretSpecRuntimeProfiles.networking = "networking";
+      secretSpecRuntimeLegacySecretNames.networking = ["ADGUARD_PASSWORD"];
+      secretSpecRuntimeHealthContainers.networking = ["swag" "adguard"];
       secretSpecRuntimeProfiles.ha-harness = "ha-harness";
       secretSpecRuntimeHealthContainers.ha-harness = ["ha-harness"];
       secretSpecRuntimeProfiles.homepage = "homepage";

--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -142,7 +142,7 @@
       "names": [
         "CLOUDFLARE_API_TOKEN"
       ],
-      "perms": "0444"
+      "perms": "0440"
     },
     {
       "destination": "/run/vault-agent/harbor.env",

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -283,7 +283,10 @@
           template {
             contents = "${renderedAt}{{ with secret \"secret/data/home/networking\" }}CLOUDFLARE_API_TOKEN={{ .Data.data.CLOUDFLARE_API_TOKEN }}\n{{ end }}"
             destination = "/run/vault-agent/networking.env"
-            perms = "0444"
+            perms = "0440"
+            exec {
+              command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/networking.env"]
+            }
           }
           # Harbor setup and the fixed mirror recipe run as root. Keep the
           # project-scoped robot beside the admin/database inputs without

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -232,6 +232,26 @@ class RuntimeProjectionTest(unittest.TestCase):
         tunneling = next(row for row in contract["renders"] if row["destination"].endswith("/tunneling.env"))
         self.assertEqual(tunneling["perms"], "0440")
 
+    def test_networking_cutover_has_exact_sources_gates_and_render_check(self):
+        compose = COMPOSE.read_text()
+        justfile = JUSTFILE.read_text()
+        vault = VAULT.read_text()
+        contract = json.loads((ROOT / "modules/hosts/discovery/vault-env-contract.json").read_text())
+        self.assertIn('secretSpecRuntimeProfiles.networking = "networking";', compose)
+        self.assertIn(
+            'secretSpecRuntimeLegacySecretNames.networking = ["ADGUARD_PASSWORD"];',
+            compose,
+        )
+        self.assertIn(
+            'secretSpecRuntimeHealthContainers.networking = ["swag" "adguard"];',
+            compose,
+        )
+        self.assertIn("verify-networking-secret-render:", justfile)
+        self.assertIn('test "$actual" = CLOUDFLARE_API_TOKEN', justfile)
+        self.assertIn('["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/networking.env"]', vault)
+        networking = next(row for row in contract["renders"] if row["destination"].endswith("/networking.env"))
+        self.assertEqual(networking["perms"], "0440")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- authorize the exact mixed-source networking SecretSpec profile
- source `CLOUDFLARE_API_TOKEN` from hardened Vault Agent render and explicitly allowlist SOPS `ADGUARD_PASSWORD`
- gate startup on SWAG and AdGuard health
- add value-free render verification

## Verification
- `python -m unittest tests/discovery-secret-contract/test_runtime_projection.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`

Critical scope: networking only. Infra remains excluded.