### PR TITLE
feat(secrets): cut over infra runtime

### DIFF
--- a/justfile
+++ b/justfile
@@ -2386,6 +2386,27 @@ verify-networking-secret-render:
       echo "networking_render=ready mode=0440 owner=root group=docker fresh=true"
     '
 
+# Prove the critical infra render is fresh and least-privilege without printing it.
+verify-infra-secret-render:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP="$(just _host-ip discovery)"
+    ssh -p 2222 erik@"$IP" '
+      set -euo pipefail
+      sudo systemctl is-active vault-agent.service
+      test "$(sudo stat -c '"'"'%a %U %G'"'"' /run/vault-agent/shared-db.env)" = "440 root docker"
+      sudo -u erik head -c0 /run/vault-agent/shared-db.env
+      if sudo -u nobody head -c0 /run/vault-agent/shared-db.env 2>/dev/null; then
+        echo "nobody unexpectedly read infra render" >&2
+        exit 1
+      fi
+      sudo find /run/vault-agent/shared-db.env -mmin -15 -print -quit | grep -q .
+      actual="$(sudo grep -v '^#' /run/vault-agent/shared-db.env | cut -d= -f1 | sort -u)"
+      expected="$(printf "POSTGRES_PASSWORD\nREDIS_PASSWORD")"
+      test "$actual" = "$expected"
+      echo "infra_render=ready mode=0440 owner=root group=docker fresh=true"
+    '
+
 # Prove the DS8 ha-harness render is fresh and least-privilege without printing it.
 verify-ha-harness-secret-render:
     #!/usr/bin/env bash

--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -25,6 +25,13 @@ _: {
       secretSpecRuntimeProfiles.networking = "networking";
       secretSpecRuntimeLegacySecretNames.networking = ["ADGUARD_PASSWORD"];
       secretSpecRuntimeHealthContainers.networking = ["swag" "adguard"];
+      secretSpecRuntimeProfiles.infra = "infra";
+      secretSpecRuntimeLegacySecretNames.infra = [
+        "MINIO_TFSTATE_ROOT_PASSWORD"
+        "VAULTWARDEN_ADMIN_TOKEN"
+        "VAULT_DEV_ROOT_TOKEN"
+      ];
+      secretSpecRuntimeHealthContainers.infra = ["postgres" "redis" "vault" "vaultwarden" "minio-tfstate"];
       secretSpecRuntimeProfiles.ha-harness = "ha-harness";
       secretSpecRuntimeHealthContainers.ha-harness = ["ha-harness"];
       secretSpecRuntimeProfiles.homepage = "homepage";

--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -55,6 +55,7 @@
     },
     {
       "destination": "/run/vault-agent/tunneling.env",
+      "group": "docker",
       "names": [
         "CLOUDFLARE_TUNNEL_TOKEN"
       ],
@@ -74,11 +75,12 @@
     },
     {
       "destination": "/run/vault-agent/shared-db.env",
+      "group": "docker",
       "names": [
         "POSTGRES_PASSWORD",
         "REDIS_PASSWORD"
       ],
-      "perms": "0444"
+      "perms": "0440"
     },
     {
       "destination": "/run/vault-agent/shared-arr.env",
@@ -139,6 +141,7 @@
     },
     {
       "destination": "/run/vault-agent/networking.env",
+      "group": "docker",
       "names": [
         "CLOUDFLARE_API_TOKEN"
       ],
@@ -172,5 +175,5 @@
     "user": "root"
   },
   "source": "modules/hosts/discovery/vault.nix",
-  "source_sha256": "8ece31a6673c4c3761c819f643e88c54d3e3063ebff93b9d5fa779df19fc70b8"
+  "source_sha256": "9dd32502169307f96795ece44941e1545667b2d40c83fd8411ace919ed4dac12"
 }

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -241,7 +241,10 @@
           template {
             contents = "${renderedAt}{{ with secret \"secret/data/home/shared-db\" }}POSTGRES_PASSWORD={{ .Data.data.POSTGRES_PASSWORD }}\nREDIS_PASSWORD={{ .Data.data.REDIS_PASSWORD }}\n{{ end }}"
             destination = "/run/vault-agent/shared-db.env"
-            perms = "0444"
+            perms = "0440"
+            exec {
+              command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/shared-db.env"]
+            }
           }
           # P3.3 shared: arr API keys (media + homepage) and grafana admin creds
           # (monitoring + homepage). Each consumer lists these in vaultEnvStacks.

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -252,6 +252,27 @@ class RuntimeProjectionTest(unittest.TestCase):
         networking = next(row for row in contract["renders"] if row["destination"].endswith("/networking.env"))
         self.assertEqual(networking["perms"], "0440")
 
+    def test_infra_cutover_has_exact_sources_gates_and_render_check(self):
+        compose = COMPOSE.read_text()
+        justfile = JUSTFILE.read_text()
+        vault = VAULT.read_text()
+        contract = json.loads((ROOT / "modules/hosts/discovery/vault-env-contract.json").read_text())
+        self.assertIn('secretSpecRuntimeProfiles.infra = "infra";', compose)
+        self.assertIn(
+            'secretSpecRuntimeLegacySecretNames.infra = [\n        "MINIO_TFSTATE_ROOT_PASSWORD"\n        "VAULTWARDEN_ADMIN_TOKEN"\n        "VAULT_DEV_ROOT_TOKEN"\n      ];',
+            compose,
+        )
+        self.assertIn(
+            'secretSpecRuntimeHealthContainers.infra = ["postgres" "redis" "vault" "vaultwarden" "minio-tfstate"];',
+            compose,
+        )
+        self.assertIn("verify-infra-secret-render:", justfile)
+        self.assertIn('expected="$(printf "POSTGRES_PASSWORD\\nREDIS_PASSWORD")"', justfile)
+        self.assertIn('["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/shared-db.env"]', vault)
+        shared_db = next(row for row in contract["renders"] if row["destination"].endswith("/shared-db.env"))
+        self.assertEqual(shared_db["perms"], "0440")
+        self.assertEqual(shared_db["group"], "docker")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- enable the Discovery `infra` SecretSpec runtime profile
- retain only MinIO, Vaultwarden, and development Vault bootstrap secrets in SOPS
- restrict `shared-db.env` to `0440 root:docker`
- gate PostgreSQL, Redis, Vault, Vaultwarden, and MinIO health
- add value-free live render verification

## Verification
- `python3 -m unittest tests/discovery-secret-contract/test_runtime_projection.py tests/discovery-secret-contract/test_vault_surface.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`

Four older unit tests still assert the retired scalar health-container API; unchanged on main and unrelated to this slice.