### PR TITLE
feat(discovery): source Kindle secrets from Vault

### DIFF
--- a/modules/hosts/discovery/_vault-agent.nix
+++ b/modules/hosts/discovery/_vault-agent.nix
@@ -132,6 +132,17 @@ in {
           contents = "{{ with secret \"secret/data/home/ha-harness-litellm\" }}LITELLM_API_KEY={{ .Data.data.LITELLM_API_KEY }}\n{{ end }}{{ with secret \"secret/data/home/ha-harness\" }}HA_HARNESS_TOKEN={{ .Data.data.HA_HARNESS_TOKEN }}\n{{ end }}"
           destination = "/run/vault-agent/ha-harness.env"
           perms = "0440"
+          exec {
+            command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/ha-harness.env"]
+          }
+        }
+        template {
+          contents = "{{ with secret \"secret/data/home/kindle-dash\" }}KINDLE_DASH_CLAUDE_REFRESH_TOKEN={{ .Data.data.KINDLE_DASH_CLAUDE_REFRESH_TOKEN }}\nKINDLE_DASH_CODEX_REFRESH_TOKEN={{ .Data.data.KINDLE_DASH_CODEX_REFRESH_TOKEN }}\nKINDLE_DASH_HA_TOKEN={{ .Data.data.KINDLE_DASH_HA_TOKEN }}\nKINDLE_DASH_OPENCODE_AUTH_COOKIE={{ .Data.data.KINDLE_DASH_OPENCODE_AUTH_COOKIE }}\n{{ end }}"
+          destination = "/run/vault-agent/kindle-dash.env"
+          perms = "0440"
+          exec {
+            command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/kindle-dash.env"]
+          }
         }
       ''}";
     };

--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -16,6 +16,7 @@ _: {
         "media-server" = ["media-server" "shared-db"];
         "ai-serving" = ["ai-serving" "shared-db"];
         "ha-harness" = ["ha-harness"];
+        "kindle-dash" = ["kindle-dash"];
         infra = ["shared-db"];
       };
       secretSpecRuntimeProfiles.tools = "tools";
@@ -50,12 +51,6 @@ _: {
       secretSpecRuntimeLegacySecretNames.plex = ["PLEX_CLAIM"];
       secretSpecRuntimeHealthContainers.plex = ["plex"];
       secretSpecRuntimeProfiles."kindle-dash" = "kindle-dash";
-      secretSpecRuntimeLegacySecretNames."kindle-dash" = [
-        "KINDLE_DASH_CLAUDE_REFRESH_TOKEN"
-        "KINDLE_DASH_CODEX_REFRESH_TOKEN"
-        "KINDLE_DASH_HA_TOKEN"
-        "KINDLE_DASH_OPENCODE_AUTH_COOKIE"
-      ];
       secretSpecRuntimeHealthContainers."kindle-dash" = ["kindle-dash"];
       secretSpecRuntimeProfiles."ai-serving" = "ai-serving";
       secretSpecRuntimeSourceConfigNames."ai-serving" = ["LANGFUSE_PUBLIC_KEY" "LANGFUSE_SALT"];

--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -16,6 +16,10 @@
     "HEALTHCHECKS_SECRET_KEY",
     "HEALTHCHECKS_SUPERUSER_PASSWORD",
     "JELLYSTAT_JWT_SECRET",
+    "KINDLE_DASH_CLAUDE_REFRESH_TOKEN",
+    "KINDLE_DASH_CODEX_REFRESH_TOKEN",
+    "KINDLE_DASH_HA_TOKEN",
+    "KINDLE_DASH_OPENCODE_AUTH_COOKIE",
     "LANGFUSE_INIT_USER_PASSWORD",
     "LANGFUSE_PUBLIC_KEY",
     "LANGFUSE_SALT",
@@ -165,6 +169,17 @@
         "LITELLM_API_KEY"
       ],
       "perms": "0440"
+    },
+    {
+      "destination": "/run/vault-agent/kindle-dash.env",
+      "group": "docker",
+      "names": [
+        "KINDLE_DASH_CLAUDE_REFRESH_TOKEN",
+        "KINDLE_DASH_CODEX_REFRESH_TOKEN",
+        "KINDLE_DASH_HA_TOKEN",
+        "KINDLE_DASH_OPENCODE_AUTH_COOKIE"
+      ],
+      "perms": "0440"
     }
   ],
   "schema_version": 1,
@@ -175,5 +190,5 @@
     "user": "root"
   },
   "source": "modules/hosts/discovery/vault.nix",
-  "source_sha256": "61f100f824d08b66c8097a3af35b3bfbc89d86cc2c1bb6987268ae49b4f2ce0e"
+  "source_sha256": "7730da8c770746f821c9b1e3c6af2f26876832f4357d06fdef719fcdefa5f7d6"
 }

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -315,6 +315,14 @@ in {
               command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/ha-harness.env"]
             }
           }
+          template {
+            contents = "${renderedAt}{{ with secret \"secret/data/home/kindle-dash\" }}KINDLE_DASH_CLAUDE_REFRESH_TOKEN={{ .Data.data.KINDLE_DASH_CLAUDE_REFRESH_TOKEN }}\nKINDLE_DASH_CODEX_REFRESH_TOKEN={{ .Data.data.KINDLE_DASH_CODEX_REFRESH_TOKEN }}\nKINDLE_DASH_HA_TOKEN={{ .Data.data.KINDLE_DASH_HA_TOKEN }}\nKINDLE_DASH_OPENCODE_AUTH_COOKIE={{ .Data.data.KINDLE_DASH_OPENCODE_AUTH_COOKIE }}\n{{ end }}"
+            destination = "/run/vault-agent/kindle-dash.env"
+            perms = "0440"
+            exec {
+              command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/kindle-dash.env"]
+            }
+          }
         ''}";
       };
     };

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -54,7 +54,7 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
             self.assertEqual(contract["schema_version"], 1)
             self.assertEqual(contract["owner"], "desktop-nixos")
             self.assertEqual(contract["source"], "modules/hosts/discovery/vault.nix")
-            self.assertEqual(len(contract["names"]), 40)
+            self.assertEqual(len(contract["names"]), 44)
             self.assertEqual(contract["names"], sorted(contract["names"]))
             self.assertIn("CLOUDFLARE_API_TOKEN", contract["names"])
             self.assertIn("HARBOR_ROBOT_SECRET", contract["names"])
@@ -105,6 +105,22 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
             source = (ROOT / relative).read_text()
             self.assertIn('secret \\"secret/data/home/ha-harness-litellm\\"', source)
             self.assertIn('secret \\"secret/data/home/ha-harness\\"', source)
+
+    def test_kindle_dash_runtime_secrets_come_from_vault_agent(self):
+        compose = (ROOT / "modules/hosts/discovery/compose.nix").read_text()
+        self.assertIn('"kindle-dash" = ["kindle-dash"];', compose)
+        self.assertNotIn('secretSpecRuntimeLegacySecretNames."kindle-dash"', compose)
+        for relative in (
+            "modules/hosts/discovery/vault.nix",
+            "modules/hosts/discovery/_vault-agent.nix",
+        ):
+            source = (ROOT / relative).read_text()
+            self.assertIn('secret \\"secret/data/home/kindle-dash\\"', source)
+            self.assertIn('destination = "/run/vault-agent/kindle-dash.env"', source)
+            self.assertIn(
+                '["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/kindle-dash.env"]',
+                source,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
S09 Kindle slice: adds a four-name Vault Agent render, switches Kindle SecretSpec from legacy SOPS to the Vault provider, and republishes the value-free contract. SOPS values remain encrypted for rollback; no deletion or rotation.