### PR TITLE
fix(discovery): quote AdGuard seed script

### DIFF
--- a/justfile
+++ b/justfile
@@ -2516,13 +2516,13 @@ seed-adguard-vault:
       unset value_b64
       curl --header @"$header" --silent --show-error --fail \
         http://127.0.0.1:8200/v1/secret/data/home/networking > "$current"
-      jq -s '{data:(.[0].data.data + .[1])}' "$current" "$incoming" > "$payload"
+      jq -s "{data:(.[0].data.data + .[1])}" "$current" "$incoming" > "$payload"
       curl --header @"$header" --silent --show-error --fail --request POST \
         --data-binary @"$payload" \
         http://127.0.0.1:8200/v1/secret/data/home/networking >/dev/null
       curl --header @"$header" --silent --show-error --fail \
         http://127.0.0.1:8200/v1/secret/data/home/networking |
-        jq -e '.data.data | has("ADGUARD_PASSWORD") and has("CLOUDFLARE_API_TOKEN")' >/dev/null
+        jq -e ".data.data | has(\"ADGUARD_PASSWORD\") and has(\"CLOUDFLARE_API_TOKEN\")" >/dev/null
       echo "adguard_vault=seeded networking_keys_verified=true"
     '
 

--- a/modules/hosts/discovery/_vault-agent.nix
+++ b/modules/hosts/discovery/_vault-agent.nix
@@ -122,6 +122,9 @@ in {
           contents = "{{ with secret \"secret/data/home/networking\" }}ADGUARD_PASSWORD={{ .Data.data.ADGUARD_PASSWORD }}\nCLOUDFLARE_API_TOKEN={{ .Data.data.CLOUDFLARE_API_TOKEN }}\n{{ end }}"
           destination = "/run/vault-agent/networking.env"
           perms = "0440"
+          exec {
+            command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/networking.env"]
+          }
         }
         template {
           contents = "{{ with secret \"secret/data/home/harbor\" }}HARBOR_ADMIN_PASSWORD={{ .Data.data.HARBOR_ADMIN_PASSWORD }}\nHARBOR_DB_PASSWORD={{ .Data.data.HARBOR_DB_PASSWORD }}\nHARBOR_ROBOT_USER={{ .Data.data.HARBOR_ROBOT_USER }}\nHARBOR_ROBOT_SECRET={{ .Data.data.HARBOR_ROBOT_SECRET }}\n{{ end }}"

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -16,6 +16,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "modules/server/_secretspec-runtime-projection.py"
 ORCHESTRATION = ROOT / "modules/server/orchestration.nix"
 VAULT = ROOT / "modules/hosts/discovery/vault.nix"
+VAULT_AGENT = ROOT / "modules/hosts/discovery/_vault-agent.nix"
 COMPOSE = ROOT / "modules/hosts/discovery/compose.nix"
 JUSTFILE = ROOT / "justfile"
 
@@ -235,6 +236,7 @@ class RuntimeProjectionTest(unittest.TestCase):
         compose = COMPOSE.read_text()
         justfile = JUSTFILE.read_text()
         vault = VAULT.read_text()
+        vault_agent = VAULT_AGENT.read_text()
         contract = json.loads((ROOT / "modules/hosts/discovery/vault-env-contract.json").read_text())
         self.assertIn('secretSpecRuntimeProfiles.networking = "networking";', compose)
         self.assertNotIn("secretSpecRuntimeLegacySecretNames.networking", compose)
@@ -246,6 +248,7 @@ class RuntimeProjectionTest(unittest.TestCase):
         self.assertIn("seed-adguard-vault:", justfile)
         self.assertIn('ADGUARD_PASSWORD\\nCLOUDFLARE_API_TOKEN', justfile)
         self.assertIn('["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/networking.env"]', vault)
+        self.assertIn('["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/networking.env"]', vault_agent)
         networking = next(row for row in contract["renders"] if row["destination"].endswith("/networking.env"))
         self.assertEqual(networking["perms"], "0440")
 


### PR DESCRIPTION
Fix nested shell quoting in the value-free OpenBao seed recipe.

Verified by executing the recipe successfully, plus secret-contract tests, lint, and fmt.