### PR TITLE
fix(ssh): replace managed config atomically

### DIFF
--- a/modules/ssh.nix
+++ b/modules/ssh.nix
@@ -53,8 +53,10 @@ _: {
           User erik
       '';
       onChange = ''
-        cp ~/.ssh/ro_config ~/.ssh/config
-        chmod 0400 ~/.ssh/config
+        config_tmp="$(mktemp ~/.ssh/config.XXXXXX)"
+        trap 'rm -f "$config_tmp"' EXIT
+        install -m 0400 ~/.ssh/ro_config "$config_tmp"
+        mv -f "$config_tmp" ~/.ssh/config
       '';
     };
   };

--- a/tests/ssh-config/test_ssh_config.py
+++ b/tests/ssh-config/test_ssh_config.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+SSH_MODULE = Path(__file__).parents[2] / "modules/ssh.nix"
+
+
+def test_read_only_config_is_replaced_atomically():
+    text = SSH_MODULE.read_text()
+    assert "mktemp ~/.ssh/config.XXXXXX" in text
+    assert 'mv -f "$config_tmp" ~/.ssh/config' in text


### PR DESCRIPTION
Fix Home Manager activation when the previous managed SSH config is mode `0400`. Write a secure temporary file, then atomically rename it over the old file.

Verified: focused test, lint, fmt, and `just dry endeavour`.