### PR TITLE
feat(secrets): cut over ai-serving runtime

### DIFF
--- a/justfile
+++ b/justfile
@@ -2571,6 +2571,54 @@ seed-infra-vault:
       echo "infra_vault=seeded keys=3"
     '
 
+# Merge the two remaining encrypted ai-serving runtime credentials into OpenBao.
+seed-ai-serving-vault:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    servarr_repo="$(readlink -f references/repos/servarr)"
+    incoming="$(mktemp)"
+    trap 'rm -f "$incoming"' EXIT
+    chmod 600 "$incoming"
+    sops --decrypt --input-type dotenv --output-type json \
+      "$servarr_repo/machines/discovery/.env.sops" |
+      jq -e '{
+        LITELLM_MASTER_KEY,
+        OPENCODE_ZEN_KEY
+      } | select(all(.[]; type == "string" and length > 0))' > "$incoming"
+    token="$(
+      sops --decrypt --extract '["vault_root_token"]' secrets/sops/secrets.yaml
+    )"
+    {
+      printf '%s' "$token" | base64 -w0
+      printf '\n'
+      base64 -w0 "$incoming"
+      printf '\n'
+    } | ssh -p 2222 erik@{{ip_discovery}} '
+      set -euo pipefail
+      IFS= read -r token_b64
+      IFS= read -r incoming_b64
+      header="$(mktemp)"
+      current="$(mktemp)"
+      incoming="$(mktemp)"
+      payload="$(mktemp)"
+      trap "rm -f \"$header\" \"$current\" \"$incoming\" \"$payload\"" EXIT
+      chmod 600 "$header" "$current" "$incoming" "$payload"
+      printf "X-Vault-Token: %s\n" "$(printf "%s" "$token_b64" | base64 --decode)" > "$header"
+      unset token_b64
+      printf "%s" "$incoming_b64" | base64 --decode > "$incoming"
+      unset incoming_b64
+      curl --header @"$header" --silent --show-error --fail \
+        http://127.0.0.1:8200/v1/secret/data/home/ai-serving > "$current"
+      jq -s "{data:(.[0].data.data + .[1])}" "$current" "$incoming" > "$payload"
+      curl --header @"$header" --silent --show-error --fail --request POST \
+        --data-binary @"$payload" \
+        http://127.0.0.1:8200/v1/secret/data/home/ai-serving >/dev/null
+      curl --header @"$header" --silent --show-error --fail \
+        http://127.0.0.1:8200/v1/secret/data/home/ai-serving |
+        jq -e ".data.data | has(\"LITELLM_MASTER_KEY\") and has(\"OPENCODE_ZEN_KEY\")" >/dev/null
+      echo "ai_serving_vault=seeded keys_added=2"
+    '
+
 # Prove the critical infra render is fresh and least-privilege without printing it.
 verify-infra-secret-render:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -2619,6 +2619,34 @@ seed-ai-serving-vault:
       echo "ai_serving_vault=seeded keys_added=2"
     '
 
+# Prove the ai-serving render is fresh and contains only the declared names.
+verify-ai-serving-secret-render:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP="$(just _host-ip discovery)"
+    ssh -p 2222 erik@"$IP" '
+      set -euo pipefail
+      sudo systemctl is-active vault-agent.service
+      metadata="$(sudo stat -c '"'"'%a %U %G'"'"' /run/vault-agent/ai-serving.env)"
+      test "$metadata" = "440 root vault-consumers" || {
+        echo "unexpected metadata: $metadata" >&2
+        exit 1
+      }
+      sudo -u erik head -c0 /run/vault-agent/ai-serving.env
+      sudo find /run/vault-agent/ai-serving.env -mmin -15 -print -quit | grep -q . || {
+        echo "render is older than 15 minutes" >&2
+        exit 1
+      }
+      actual="$(sudo grep -v "^#" /run/vault-agent/ai-serving.env | cut -d= -f1 | sort -u)"
+      expected="$(printf "CLICKHOUSE_PASSWORD\nLANGFUSE_INIT_USER_PASSWORD\nLANGFUSE_PUBLIC_KEY\nLANGFUSE_SALT\nLANGFUSE_SECRET_KEY\nLITELLM_MASTER_KEY\nLITELLM_SALT_KEY\nMINIO_ROOT_PASSWORD\nOPENCODE_GO_KEY\nOPENCODE_ZEN_KEY\nUI_PASSWORD")"
+      test "$actual" = "$expected" || {
+        echo "unexpected names:" >&2
+        printf "%s\n" "$actual" >&2
+        exit 1
+      }
+      echo "ai_serving_render=ready mode=0440 owner=root group=vault-consumers fresh=true keys=11"
+    '
+
 # Prove the critical infra render is fresh and least-privilege without printing it.
 verify-infra-secret-render:
     #!/usr/bin/env bash

--- a/modules/hosts/discovery/_vault-agent.nix
+++ b/modules/hosts/discovery/_vault-agent.nix
@@ -117,7 +117,7 @@ in {
           perms = "0440"
         }
         template {
-          contents = "{{ with secret \"secret/data/home/ai-serving\" }}LITELLM_SALT_KEY={{ .Data.data.LITELLM_SALT_KEY }}\nLANGFUSE_PUBLIC_KEY={{ .Data.data.LANGFUSE_PUBLIC_KEY }}\nLANGFUSE_SECRET_KEY={{ .Data.data.LANGFUSE_SECRET_KEY }}\nLANGFUSE_SALT={{ .Data.data.LANGFUSE_SALT }}\nLANGFUSE_INIT_USER_PASSWORD={{ .Data.data.LANGFUSE_INIT_USER_PASSWORD }}\nOPENCODE_GO_KEY={{ .Data.data.OPENCODE_GO_KEY }}\nUI_PASSWORD={{ .Data.data.UI_PASSWORD }}\nMINIO_ROOT_PASSWORD={{ .Data.data.MINIO_ROOT_PASSWORD }}\nCLICKHOUSE_PASSWORD={{ .Data.data.CLICKHOUSE_PASSWORD }}\n{{ end }}"
+          contents = "{{ with secret \"secret/data/home/ai-serving\" }}LITELLM_MASTER_KEY={{ .Data.data.LITELLM_MASTER_KEY }}\nLITELLM_SALT_KEY={{ .Data.data.LITELLM_SALT_KEY }}\nLANGFUSE_PUBLIC_KEY={{ .Data.data.LANGFUSE_PUBLIC_KEY }}\nLANGFUSE_SECRET_KEY={{ .Data.data.LANGFUSE_SECRET_KEY }}\nLANGFUSE_SALT={{ .Data.data.LANGFUSE_SALT }}\nLANGFUSE_INIT_USER_PASSWORD={{ .Data.data.LANGFUSE_INIT_USER_PASSWORD }}\nOPENCODE_GO_KEY={{ .Data.data.OPENCODE_GO_KEY }}\nOPENCODE_ZEN_KEY={{ .Data.data.OPENCODE_ZEN_KEY }}\nUI_PASSWORD={{ .Data.data.UI_PASSWORD }}\nMINIO_ROOT_PASSWORD={{ .Data.data.MINIO_ROOT_PASSWORD }}\nCLICKHOUSE_PASSWORD={{ .Data.data.CLICKHOUSE_PASSWORD }}\n{{ end }}"
           destination = "/run/vault-agent/ai-serving.env"
           perms = "0440"
         }

--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -48,7 +48,6 @@ _: {
       secretSpecRuntimeHealthContainers."kindle-dash" = ["kindle-dash"];
       secretSpecRuntimeProfiles."ai-serving" = "ai-serving";
       secretSpecRuntimeSourceConfigNames."ai-serving" = ["LANGFUSE_PUBLIC_KEY" "LANGFUSE_SALT"];
-      secretSpecRuntimeLegacySecretNames."ai-serving" = ["LITELLM_MASTER_KEY" "OPENCODE_ZEN_KEY"];
       secretSpecRuntimeHealthContainers."ai-serving" = ["litellm" "langfuse-clickhouse" "langfuse-web" "langfuse-worker"];
       stacks = [
         # shared.yml has no services on discovery (alloy/syncthing/etc run natively)

--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -27,12 +27,14 @@
     "LANGFUSE_SECRET_KEY",
     "LIDARR_API_KEY",
     "LITELLM_API_KEY",
+    "LITELLM_MASTER_KEY",
     "LITELLM_SALT_KEY",
     "MINIO_ROOT_PASSWORD",
     "MINIO_TFSTATE_ROOT_PASSWORD",
     "NORDVPN_PASSWORD",
     "NORDVPN_USER",
     "OPENCODE_GO_KEY",
+    "OPENCODE_ZEN_KEY",
     "POSTGRES_PASSWORD",
     "QBITTORRENT_PASSWORD",
     "QBITTORRENT_USER",
@@ -140,9 +142,11 @@
         "LANGFUSE_PUBLIC_KEY",
         "LANGFUSE_SALT",
         "LANGFUSE_SECRET_KEY",
+        "LITELLM_MASTER_KEY",
         "LITELLM_SALT_KEY",
         "MINIO_ROOT_PASSWORD",
         "OPENCODE_GO_KEY",
+        "OPENCODE_ZEN_KEY",
         "UI_PASSWORD"
       ],
       "perms": "0444"
@@ -205,5 +209,5 @@
     "user": "root"
   },
   "source": "modules/hosts/discovery/vault.nix",
-  "source_sha256": "802fc365bd1fd54c8a8ff0fd6ac0249641cbe86a9b51e783c9786b393eb8dc6b"
+  "source_sha256": "5b14c8c4515b271303930d7add7866d2aeeaec94922284785fe1159546ffdb65"
 }

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -287,7 +287,7 @@ in {
             perms = "0444"
           }
           template {
-            contents = "${renderedAt}{{ with secret \"secret/data/home/ai-serving\" }}LITELLM_SALT_KEY={{ .Data.data.LITELLM_SALT_KEY }}\nLANGFUSE_PUBLIC_KEY={{ .Data.data.LANGFUSE_PUBLIC_KEY }}\nLANGFUSE_SECRET_KEY={{ .Data.data.LANGFUSE_SECRET_KEY }}\nLANGFUSE_SALT={{ .Data.data.LANGFUSE_SALT }}\nLANGFUSE_INIT_USER_PASSWORD={{ .Data.data.LANGFUSE_INIT_USER_PASSWORD }}\nOPENCODE_GO_KEY={{ .Data.data.OPENCODE_GO_KEY }}\nUI_PASSWORD={{ .Data.data.UI_PASSWORD }}\nMINIO_ROOT_PASSWORD={{ .Data.data.MINIO_ROOT_PASSWORD }}\nCLICKHOUSE_PASSWORD={{ .Data.data.CLICKHOUSE_PASSWORD }}\n{{ end }}"
+            contents = "${renderedAt}{{ with secret \"secret/data/home/ai-serving\" }}LITELLM_MASTER_KEY={{ .Data.data.LITELLM_MASTER_KEY }}\nLITELLM_SALT_KEY={{ .Data.data.LITELLM_SALT_KEY }}\nLANGFUSE_PUBLIC_KEY={{ .Data.data.LANGFUSE_PUBLIC_KEY }}\nLANGFUSE_SECRET_KEY={{ .Data.data.LANGFUSE_SECRET_KEY }}\nLANGFUSE_SALT={{ .Data.data.LANGFUSE_SALT }}\nLANGFUSE_INIT_USER_PASSWORD={{ .Data.data.LANGFUSE_INIT_USER_PASSWORD }}\nOPENCODE_GO_KEY={{ .Data.data.OPENCODE_GO_KEY }}\nOPENCODE_ZEN_KEY={{ .Data.data.OPENCODE_ZEN_KEY }}\nUI_PASSWORD={{ .Data.data.UI_PASSWORD }}\nMINIO_ROOT_PASSWORD={{ .Data.data.MINIO_ROOT_PASSWORD }}\nCLICKHOUSE_PASSWORD={{ .Data.data.CLICKHOUSE_PASSWORD }}\n{{ end }}"
             destination = "/run/vault-agent/ai-serving.env"
             perms = "0444"
           }

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -191,11 +191,11 @@ class RuntimeProjectionTest(unittest.TestCase):
             'secretSpecRuntimeHealthContainers."kindle-dash" = ["kindle-dash"];',
             'secretSpecRuntimeProfiles."ai-serving" = "ai-serving";',
             'secretSpecRuntimeSourceConfigNames."ai-serving" = ["LANGFUSE_PUBLIC_KEY" "LANGFUSE_SALT"];',
-            'secretSpecRuntimeLegacySecretNames."ai-serving" = ["LITELLM_MASTER_KEY" "OPENCODE_ZEN_KEY"];',
             'secretSpecRuntimeHealthContainers."ai-serving" = ["litellm" "langfuse-clickhouse" "langfuse-web" "langfuse-worker"];',
         ]
         for declaration in expected:
             self.assertIn(declaration, source)
+        self.assertNotIn('secretSpecRuntimeLegacySecretNames."ai-serving"', source)
         self.assertIn(
             'secretSpecRuntimeHealthContainers.monitoring = ["grafana" "healthchecks" "scrutiny-influxdb" "scrutiny"];',
             source,

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -54,7 +54,7 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
             self.assertEqual(contract["schema_version"], 1)
             self.assertEqual(contract["owner"], "desktop-nixos")
             self.assertEqual(contract["source"], "modules/hosts/discovery/vault.nix")
-            self.assertEqual(len(contract["names"]), 48)
+            self.assertEqual(len(contract["names"]), 50)
             self.assertIn("ADGUARD_PASSWORD", contract["names"])
             self.assertEqual(contract["names"], sorted(contract["names"]))
             self.assertIn("CLOUDFLARE_API_TOKEN", contract["names"])
@@ -122,6 +122,18 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
                 '["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/kindle-dash.env"]',
                 source,
             )
+
+    def test_ai_serving_remaining_runtime_secrets_come_from_vault_agent(self):
+        for relative in (
+            "modules/hosts/discovery/vault.nix",
+            "modules/hosts/discovery/_vault-agent.nix",
+        ):
+            source = (ROOT / relative).read_text()
+            self.assertIn("LITELLM_MASTER_KEY={{ .Data.data.LITELLM_MASTER_KEY }}", source)
+            self.assertIn("OPENCODE_ZEN_KEY={{ .Data.data.OPENCODE_ZEN_KEY }}", source)
+        justfile = JUSTFILE.read_text()
+        self.assertIn("seed-ai-serving-vault:", justfile)
+        self.assertIn('echo "ai_serving_vault=seeded keys_added=2"', justfile)
 
 
 if __name__ == "__main__":

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -134,6 +134,11 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
         justfile = JUSTFILE.read_text()
         self.assertIn("seed-ai-serving-vault:", justfile)
         self.assertIn('echo "ai_serving_vault=seeded keys_added=2"', justfile)
+        self.assertIn("verify-ai-serving-secret-render:", justfile)
+        self.assertIn(
+            'echo "ai_serving_render=ready mode=0440 owner=root group=vault-consumers fresh=true keys=11"',
+            justfile,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Moves the final ai-serving runtime credentials (LiteLLM master and OpenCode Zen keys) from the SOPS fallback into the existing OpenBao/Vault Agent render. Adds a value-safe seed recipe and removes the legacy SecretSpec fallback.\n\nVerified: focused contract tests, lint, fmt-check, and Discovery dry-build.