### PR TITLE
feat(secrets): move PocketID key to Vault

### DIFF
--- a/justfile
+++ b/justfile
@@ -2649,6 +2649,74 @@ verify-ai-serving-secret-render:
       echo "ai_serving_render=ready mode=0440 owner=root group=vault-consumers fresh=true keys=11"
     '
 
+# Merge PocketID's encrypted runtime key into the existing NetBird secret.
+seed-netbird-pocketid-vault:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    value="$(
+      sops --decrypt --extract '["netbird"]["pocketid_encryption_key"]' \
+        secrets/sops/secrets.yaml
+    )"
+    test -n "$value"
+    token="$(
+      sops --decrypt --extract '["vault_root_token"]' secrets/sops/secrets.yaml
+    )"
+    {
+      printf '%s' "$token" | base64 -w0
+      printf '\n'
+      jq -cn --arg value "$value" '{POCKETID_ENCRYPTION_KEY:$value}' | base64 -w0
+      printf '\n'
+    } | ssh -p 2222 erik@{{ip_discovery}} '
+      set -euo pipefail
+      IFS= read -r token_b64
+      IFS= read -r value_b64
+      header="$(mktemp)"
+      current="$(mktemp)"
+      incoming="$(mktemp)"
+      payload="$(mktemp)"
+      trap "rm -f \"$header\" \"$current\" \"$incoming\" \"$payload\"" EXIT
+      chmod 600 "$header" "$current" "$incoming" "$payload"
+      printf "X-Vault-Token: %s\n" "$(printf "%s" "$token_b64" | base64 --decode)" > "$header"
+      unset token_b64
+      printf "%s" "$value_b64" | base64 --decode > "$incoming"
+      unset value_b64
+      status="$(
+        curl --header @"$header" --silent --show-error \
+          --output "$current" --write-out "%{http_code}" \
+          http://127.0.0.1:8200/v1/secret/data/home/netbird
+      )"
+      case "$status" in
+        200) ;;
+        404) printf "{\"data\":{\"data\":{}}}" > "$current" ;;
+        *) echo "netbird PocketID Vault read failed: HTTP $status" >&2; exit 1 ;;
+      esac
+      jq -s "{data:(.[0].data.data + .[1])}" "$current" "$incoming" > "$payload"
+      curl --header @"$header" --silent --show-error --fail --request POST \
+        --data-binary @"$payload" \
+        http://127.0.0.1:8200/v1/secret/data/home/netbird >/dev/null
+      echo "netbird_pocketid_vault=seeded keys_added=1"
+    '
+
+# Verify metadata and dotenv name without exposing the key.
+verify-netbird-pocketid-secret-render:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP="$(just _host-ip discovery)"
+    ssh -p 2222 erik@"$IP" '
+      set -euo pipefail
+      sudo systemctl is-active vault-agent.service
+      metadata="$(sudo stat -c '"'"'%a %U %G'"'"' /run/vault-agent/netbird-pocketid.env)"
+      test "$metadata" = "400 root vault-consumers" ||
+        { echo "netbird_pocketid_render=bad_metadata actual=$metadata" >&2; exit 1; }
+      test "$(sudo cut -d= -f1 /run/vault-agent/netbird-pocketid.env)" = ENCRYPTION_KEY ||
+        { echo "netbird_pocketid_render=bad_name" >&2; exit 1; }
+      sudo find /run/vault-agent/netbird-pocketid.env -mmin -15 -print -quit | grep -q . ||
+        { echo "netbird_pocketid_render=stale" >&2; exit 1; }
+      sudo systemctl is-active docker-netbird-pocketid.service ||
+        { echo "netbird_pocketid_service=inactive" >&2; exit 1; }
+      echo "netbird_pocketid_render=ready mode=0400 owner=root group=vault-consumers fresh=true"
+    '
+
 # Prove the critical infra render is fresh and least-privilege without printing it.
 verify-infra-secret-render:
     #!/usr/bin/env bash

--- a/modules/hosts/discovery/_vault-agent.nix
+++ b/modules/hosts/discovery/_vault-agent.nix
@@ -130,6 +130,11 @@ in {
           }
         }
         template {
+          contents = "{{ with secret \"secret/data/home/netbird\" }}{{ .Data.data.POCKETID_ENCRYPTION_KEY }}\n{{ end }}"
+          destination = "/run/vault-agent/netbird-pocketid.env"
+          perms = "0400"
+        }
+        template {
           contents = "{{ with secret \"secret/data/home/infra\" }}MINIO_TFSTATE_ROOT_PASSWORD={{ .Data.data.MINIO_TFSTATE_ROOT_PASSWORD }}\nVAULTWARDEN_ADMIN_TOKEN={{ .Data.data.VAULTWARDEN_ADMIN_TOKEN }}\nVAULT_DEV_ROOT_TOKEN={{ .Data.data.VAULT_DEV_ROOT_TOKEN }}\n{{ end }}"
           destination = "/run/vault-agent/infra.env"
           perms = "0440"

--- a/modules/hosts/discovery/netbird-server.nix
+++ b/modules/hosts/discovery/netbird-server.nix
@@ -30,6 +30,7 @@
 # logs an auth error), not silently insecure.
 {
   config,
+  pkgs,
   self,
   ...
 }: let
@@ -184,15 +185,6 @@ in {
         # label was a misnomer (not a JWT key) — renamed to
         # `netbird/pocketid_encryption_key`. Content, Phase-S human-minted:
         # `ENCRYPTION_KEY=<openssl rand -base64 32>`.
-        sops.secrets."netbird/pocketid_encryption_key" = {
-          inherit sopsFile;
-          format = "yaml";
-          key = "netbird/pocketid_encryption_key";
-          mode = "0400";
-          path = "/run/secrets/netbird-pocketid-encryption-key";
-          restartUnits = ["docker-netbird-pocketid.service"];
-        };
-
         virtualisation.oci-containers.containers.netbird-pocketid = {
           image = "ghcr.io/pocket-id/pocket-id:${pocketIdTag}";
           volumes = ["${dataDir}/pocket-id:/app/data"];
@@ -201,9 +193,21 @@ in {
             TRUST_PROXY = "true"; # behind SWAG (§5 — tailnet/LAN-only ingress)
           };
           environmentFiles = [
-            config.sops.secrets."netbird/pocketid_encryption_key".path
+            "/run/vault-agent/netbird-pocketid.env"
           ];
           networks = ["homelab-net"];
+        };
+
+        systemd.services.docker-netbird-pocketid = {
+          after = ["vault-agent.service"];
+          requires = ["vault-agent.service"];
+          serviceConfig.ExecStartPre = pkgs.writeShellScript "wait-for-netbird-pocketid-env" ''
+            for _ in $(seq 1 100); do
+              [ -s /run/vault-agent/netbird-pocketid.env ] && exit 0
+              sleep 0.1
+            done
+            exit 1
+          '';
         };
       }
 

--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -209,5 +209,5 @@
     "user": "root"
   },
   "source": "modules/hosts/discovery/vault.nix",
-  "source_sha256": "5b14c8c4515b271303930d7add7866d2aeeaec94922284785fe1159546ffdb65"
+  "source_sha256": "ee2d152a82284aca804af5e496ea79657f453416df59135267c32be61cb60c4e"
 }

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -299,6 +299,11 @@ in {
               command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/networking.env"]
             }
           }
+          template {
+            contents = "${renderedAt}{{ with secret \"secret/data/home/netbird\" }}{{ .Data.data.POCKETID_ENCRYPTION_KEY }}\n{{ end }}"
+            destination = "/run/vault-agent/netbird-pocketid.env"
+            perms = "0400"
+          }
           # Harbor setup and the fixed mirror recipe run as root. Keep the
           # project-scoped robot beside the admin/database inputs without
           # exposing any of them to rootless Compose.

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -140,6 +140,21 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
             justfile,
         )
 
+    def test_pocketid_runtime_secret_comes_from_vault_agent(self):
+        vault = SOURCE.read_text()
+        netbird = (ROOT / "modules/hosts/discovery/netbird-server.nix").read_text()
+        self.assertIn('destination = "/run/vault-agent/netbird-pocketid.env"', vault)
+        self.assertIn(
+            '"/run/vault-agent/netbird-pocketid.env"',
+            netbird,
+        )
+        self.assertNotIn('sops.secrets."netbird/pocketid_encryption_key"', netbird)
+        self.assertIn('after = ["vault-agent.service"]', netbird)
+        self.assertIn("[ -s /run/vault-agent/netbird-pocketid.env ]", netbird)
+        justfile = JUSTFILE.read_text()
+        self.assertIn("seed-netbird-pocketid-vault:", justfile)
+        self.assertIn("verify-netbird-pocketid-secret-render:", justfile)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- render PocketID encryption key through Discovery Vault Agent
- remove the runtime SOPS projection from the PocketID unit
- add merge-safe seed and metadata-only verification recipes

## Verification
- `python3 tests/discovery-secret-contract/test_vault_surface.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`