### PR TITLE
feat(secrets): move NetBird control plane to Vault

### DIFF
--- a/justfile
+++ b/justfile
@@ -2649,22 +2649,28 @@ verify-ai-serving-secret-render:
       echo "ai_serving_render=ready mode=0440 owner=root group=vault-consumers fresh=true keys=11"
     '
 
-# Merge PocketID's encrypted runtime key into the existing NetBird secret.
-seed-netbird-pocketid-vault:
+# Merge encrypted NetBird runtime values into the existing Vault document.
+seed-netbird-vault:
     #!/usr/bin/env bash
     set -euo pipefail
-    value="$(
-      sops --decrypt --extract '["netbird"]["pocketid_encryption_key"]' \
-        secrets/sops/secrets.yaml
-    )"
-    test -n "$value"
+    pocketid="$(sops --decrypt --extract '["netbird"]["pocketid_encryption_key"]' secrets/sops/secrets.yaml)"
+    postgres="$(sops --decrypt --extract '["netbird"]["postgres_dsn"]' secrets/sops/secrets.yaml)"
+    auth="$(sops --decrypt --extract '["netbird"]["auth_secret"]' secrets/sops/secrets.yaml)"
+    datastore="$(sops --decrypt --extract '["netbird"]["datastore_enc_key"]' secrets/sops/secrets.yaml)"
+    test -n "$pocketid" && test -n "$postgres" && test -n "$auth" && test -n "$datastore"
     token="$(
       sops --decrypt --extract '["vault_root_token"]' secrets/sops/secrets.yaml
     )"
     {
       printf '%s' "$token" | base64 -w0
       printf '\n'
-      jq -cn --arg value "$value" '{POCKETID_ENCRYPTION_KEY:$value}' | base64 -w0
+      jq -cn \
+        --arg pocketid "$pocketid" \
+        --arg postgres "$postgres" \
+        --arg auth "$auth" \
+        --arg datastore "$datastore" \
+        '{POCKETID_ENCRYPTION_KEY:$pocketid,POSTGRES_DSN:$postgres,AUTH_SECRET:$auth,DATASTORE_ENC_KEY:$datastore}' |
+        base64 -w0
       printf '\n'
     } | ssh -p 2222 erik@{{ip_discovery}} '
       set -euo pipefail
@@ -2680,22 +2686,26 @@ seed-netbird-pocketid-vault:
       unset token_b64
       printf "%s" "$value_b64" | base64 --decode > "$incoming"
       unset value_b64
-      status="$(
+      http_status="$(
         curl --header @"$header" --silent --show-error \
           --output "$current" --write-out "%{http_code}" \
           http://127.0.0.1:8200/v1/secret/data/home/netbird
       )"
-      case "$status" in
+      case "$http_status" in
         200) ;;
         404) printf "{\"data\":{\"data\":{}}}" > "$current" ;;
-        *) echo "netbird PocketID Vault read failed: HTTP $status" >&2; exit 1 ;;
+        *) echo "NetBird Vault read failed: HTTP $http_status" >&2; exit 1 ;;
       esac
       jq -s "{data:(.[0].data.data + .[1])}" "$current" "$incoming" > "$payload"
       curl --header @"$header" --silent --show-error --fail --request POST \
         --data-binary @"$payload" \
         http://127.0.0.1:8200/v1/secret/data/home/netbird >/dev/null
-      echo "netbird_pocketid_vault=seeded keys_added=1"
+      echo "netbird_vault=seeded keys_added=4"
     '
+
+seed-netbird-pocketid-vault: seed-netbird-vault
+
+seed-netbird-controlplane-vault: seed-netbird-vault
 
 # Verify metadata and dotenv name without exposing the key.
 verify-netbird-pocketid-secret-render:
@@ -2715,6 +2725,27 @@ verify-netbird-pocketid-secret-render:
       sudo systemctl is-active docker-netbird-pocketid.service ||
         { echo "netbird_pocketid_service=inactive" >&2; exit 1; }
       echo "netbird_pocketid_render=ready mode=0400 owner=root group=vault-consumers fresh=true"
+    '
+
+# Verify control-plane renders and consumers without exposing values.
+verify-netbird-controlplane-secret-render:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP="$(just _host-ip discovery)"
+    ssh -p 2222 erik@"$IP" '
+      set -euo pipefail
+      sudo systemctl is-active vault-agent.service
+      for file in netbird-postgres.env netbird-auth.env netbird-datastore.key; do
+        test "$(sudo stat -c '"'"'%a %U %G'"'"' /run/vault-agent/$file)" = "400 root vault-consumers"
+        sudo find "/run/vault-agent/$file" -mmin -15 -print -quit | grep -q .
+        sudo test -s "/run/vault-agent/$file"
+      done
+      test "$(sudo cut -d= -f1 /run/vault-agent/netbird-postgres.env)" = NETBIRD_STORE_ENGINE_POSTGRES_DSN
+      test "$(sudo cut -d= -f1 /run/vault-agent/netbird-auth.env)" = NB_AUTH_SECRET
+      sudo systemctl is-active netbird-management-config.service
+      sudo systemctl is-active docker-netbird-management.service
+      sudo systemctl is-active docker-netbird-relay.service
+      echo "netbird_controlplane_render=ready mode=0400 owner=root group=vault-consumers fresh=true files=3"
     '
 
 # Prove the critical infra render is fresh and least-privilege without printing it.

--- a/modules/hosts/discovery/_vault-agent.nix
+++ b/modules/hosts/discovery/_vault-agent.nix
@@ -135,6 +135,21 @@ in {
           perms = "0400"
         }
         template {
+          contents = "{{ with secret \"secret/data/home/netbird\" }}{{ .Data.data.POSTGRES_DSN }}\n{{ end }}"
+          destination = "/run/vault-agent/netbird-postgres.env"
+          perms = "0400"
+        }
+        template {
+          contents = "{{ with secret \"secret/data/home/netbird\" }}{{ .Data.data.AUTH_SECRET }}\n{{ end }}"
+          destination = "/run/vault-agent/netbird-auth.env"
+          perms = "0400"
+        }
+        template {
+          contents = "{{ with secret \"secret/data/home/netbird\" }}{{ .Data.data.DATASTORE_ENC_KEY }}\n{{ end }}"
+          destination = "/run/vault-agent/netbird-datastore.key"
+          perms = "0400"
+        }
+        template {
           contents = "{{ with secret \"secret/data/home/infra\" }}MINIO_TFSTATE_ROOT_PASSWORD={{ .Data.data.MINIO_TFSTATE_ROOT_PASSWORD }}\nVAULTWARDEN_ADMIN_TOKEN={{ .Data.data.VAULTWARDEN_ADMIN_TOKEN }}\nVAULT_DEV_ROOT_TOKEN={{ .Data.data.VAULT_DEV_ROOT_TOKEN }}\n{{ end }}"
           destination = "/run/vault-agent/infra.env"
           perms = "0440"

--- a/modules/hosts/discovery/netbird-server.nix
+++ b/modules/hosts/discovery/netbird-server.nix
@@ -15,12 +15,8 @@
 #
 # DISABLED BY DEFAULT (services.netbirdServer.enable = false). Every value below
 # is either a public/non-secret fact (fleet.netbird.*, modules/meta.nix) or a
-# sops-secret PLACEHOLDER key that does not yet exist in secrets/sops/secrets.yaml
-# — minting the real values is Phase S (human-gated, see the implementation
-# plan). Because all of it sits under `lib.mkIf cfg.enable`, none of it
-# evaluates while disabled: `just dry discovery` stays a clean no-op even
-# though the sops keys referenced below don't exist yet, and even though
-# discovery's `default.nix` imports this module.
+# runtime secret rendered by Vault Agent. Because all of it sits under
+# `lib.mkIf cfg.enable`, none of it evaluates while disabled.
 #
 # HONEST CAVEAT (mirrors §8's own "verify against the pin at build time"):
 # NetBird's self-hosted config surface has moved more than once (v0.29 relay,
@@ -31,7 +27,6 @@
 {
   config,
   pkgs,
-  self,
   ...
 }: let
   inherit (config) username;
@@ -46,7 +41,6 @@ in {
     ...
   }: let
     cfg = config.services.netbirdServer;
-    sopsFile = self + "/secrets/sops/secrets.yaml";
     dataDir = "/home/${username}/homelab/apps/netbird"; # mirrors discovery-hermes-oci's hostDataDir convention
 
     # Image tags — current stable as of 2026-07-10 (checked docs.netbird.io,
@@ -84,7 +78,7 @@ in {
     # The ONE value that must NOT be baked into the Nix store is the relay HMAC
     # (`Relay.Secret`): it is left as the literal placeholder `$NB_AUTH_SECRET`
     # and rendered at activation by the netbird-management-config oneshot
-    # (envsubst from the sops secret into /run/netbird-management/management.json,
+    # (envsubst from the Vault Agent render into /run/netbird-management/management.json,
     # which the container mounts). CredentialsTTL raised 24h->168h (§7).
     managementConfig = pkgs.writeText "netbird-management.json.tmpl" (builtins.toJSON {
       StoreConfig.Engine = "postgres";
@@ -215,72 +209,26 @@ in {
       # management/signal/dashboard/relay#1 + their three secrets. Reached only
       # after the PocketID OIDC client and the real secrets exist (RFC §6 step 6).
       (lib.mkIf (!cfg.idpOnly) {
-        # --- Secrets (Phase S mints the real values; placeholders only) --------
-        # Single-purpose dotenv-style secrets, same shape as
-        # discovery-hermes-oci.nix's `hermes_agent/server_env` — sops-nix drops
-        # the decrypted scalar verbatim to `path`; docker's `environmentFiles`
-        # reads it as KEY=VALUE lines.
-        sops.secrets."netbird/postgres_dsn" = {
-          inherit sopsFile;
-          format = "yaml";
-          key = "netbird/postgres_dsn";
-          mode = "0400";
-          path = "/run/secrets/netbird-postgres-dsn";
-          # Q5: reuse discovery's infra Postgres (the `postgres` container on
-          # homelab-net) rather than a dedicated instance. Content is the FULL
-          # DSN line, e.g.:
-          #   NETBIRD_STORE_ENGINE_POSTGRES_DSN=postgresql://netbird:<pw>@postgres:5432/netbird?sslmode=disable
-          # TODO(Phase-O, servarr repo): provision the `netbird` role + database
-          # in discovery's infra Postgres (scripts/provision-db.sql) before this
-          # DSN is real.
-          restartUnits = ["docker-netbird-management.service"];
-        };
-        sops.secrets."netbird/auth_secret" = {
-          inherit sopsFile;
-          format = "yaml";
-          key = "netbird/auth_secret";
-          mode = "0400";
-          path = "/run/secrets/netbird-auth-secret";
-          # Content: `NB_AUTH_SECRET=<openssl rand -base64 32>` (§6b-H7 — must be
-          # IDENTICAL on management and every relay; mismatch fails silently at
-          # the relay, so verify a real peer connection in Phase-O §10-2). Stays
-          # a `NB_AUTH_SECRET=` dotenv line because the netbird-relay container
-          # reads it via environmentFiles; netbird-management-config strips the
-          # prefix before rendering it into management.json's Relay.Secret.
-          restartUnits = ["netbird-management-config.service" "docker-netbird-management.service" "docker-netbird-relay.service"];
-        };
-        sops.secrets."netbird/datastore_enc_key" = {
-          inherit sopsFile;
-          format = "yaml";
-          key = "netbird/datastore_enc_key";
-          mode = "0400";
-          path = "/run/secrets/netbird-datastore-enc-key";
-          # Content: the BARE key value `<openssl rand -base64 32>` (no NB_XXX=
-          # prefix — render-only, read raw by netbird-management-config). Encrypts
-          # netbird's at-rest data store; MUST stay stable: rotating it makes the
-          # existing store unreadable. Provided so management does NOT generate a
-          # key and try to write it back to the read-only management.json.
-          # Rendered into management.json (not env) by netbird-management-config.
-          restartUnits = ["netbird-management-config.service" "docker-netbird-management.service"];
-        };
         # NOTE: no netbird/oidc_client_secret secret — the NetBird OIDC client is
         # public + PKCE (RFC §5 / G4), so PocketID issues no client secret.
 
         # Render management.json at activation, substituting the relay HMAC from
-        # the sops secret into the store template (a real secret must never be
+        # the Vault Agent secret into the store template (a real secret must never be
         # baked into a world-readable /nix/store path). Ordered before — and
         # required by — the management container so it always has a fresh render
         # (/run is tmpfs, cleared each boot). Dir 0700 keeps the rendered secret
         # host-private; file 0444 lets the container read it regardless of its uid.
         systemd.services.netbird-management-config = {
-          description = "Render netbird management.json with the relay HMAC from sops";
+          description = "Render netbird management.json with secrets from Vault Agent";
+          after = ["vault-agent.service"];
+          requires = ["vault-agent.service"];
           before = ["docker-netbird-management.service"];
           requiredBy = ["docker-netbird-management.service"];
           serviceConfig = {
             Type = "oneshot";
             RemainAfterExit = true;
             # If the secrets are still empty after the in-script 30s wait (a
-            # longer sops race), fail and let systemd keep retrying the render so
+            # longer Vault Agent race), fail and let systemd keep retrying the render so
             # management self-heals — instead of the render staying permanently
             # failed and blocking the container (its own Restart= can't re-fire a
             # failed Requires= dependency's start job).
@@ -289,29 +237,30 @@ in {
           };
           script = ''
             install -d -m 0700 /run/netbird-management
-            # DataStoreEncryptionKey is render-only: its sops secret holds the
+            # DataStoreEncryptionKey is render-only: its Vault render holds the
             # BARE value, read straight in. The relay HMAC (Relay.Secret) is
             # shared with the netbird-relay container, which consumes it as a
-            # dotenv env-file, so its sops secret keeps the `NB_AUTH_SECRET=`
+            # dotenv env-file, so its Vault render keeps the `NB_AUTH_SECRET=`
             # line; strip the prefix here with shell param-expansion (no sed —
             # tolerant if the prefix is already absent). Do NOT source the files:
             # a stray line would execute. Wait for BOTH to be present and
             # non-empty before rendering: on an autoUpgrade the secrets can be
-            # mid-re-decryption when their restartUnits fire this oneshot, and
+            # mid-render when this oneshot starts, and
             # rendering an EMPTY DataStoreEncryptionKey makes management
             # self-generate a new key and try to write it back to the :ro config
             # mount -> crash-loop -> start-limit-hit (observed 2026-07-12, mgmt
             # down ~5h). Refusing to render an empty config keeps management from
             # ever seeing one — it waits for a good render instead.
             for _ in $(seq 1 30); do
-              NB_AUTH_SECRET_LINE="$(cat ${config.sops.secrets."netbird/auth_secret".path})"
+              NB_AUTH_SECRET_LINE="$(cat /run/vault-agent/netbird-auth.env 2>/dev/null || true)"
               NB_AUTH_SECRET="''${NB_AUTH_SECRET_LINE#NB_AUTH_SECRET=}"
-              NB_DATASTORE_ENC_KEY="$(cat ${config.sops.secrets."netbird/datastore_enc_key".path})"
-              [ -n "$NB_AUTH_SECRET" ] && [ -n "$NB_DATASTORE_ENC_KEY" ] && break
+              NB_DATASTORE_ENC_KEY="$(cat /run/vault-agent/netbird-datastore.key 2>/dev/null || true)"
+              [ -s /run/vault-agent/netbird-postgres.env ] &&
+                [ -n "$NB_AUTH_SECRET" ] && [ -n "$NB_DATASTORE_ENC_KEY" ] && break
               sleep 1
             done
             if [ -z "$NB_AUTH_SECRET" ] || [ -z "$NB_DATASTORE_ENC_KEY" ]; then
-              echo "netbird-management-config: sops secrets still empty after 30s; refusing to render an empty config" >&2
+              echo "netbird-management-config: Vault Agent secrets still empty after 30s; refusing to render an empty config" >&2
               exit 1
             fi
             export NB_AUTH_SECRET NB_DATASTORE_ENC_KEY
@@ -351,7 +300,7 @@ in {
             # into management.json by the netbird-management-config oneshot, not
             # passed as env here.
             environmentFiles = [
-              config.sops.secrets."netbird/postgres_dsn".path
+              "/run/vault-agent/netbird-postgres.env"
             ];
             # No published host ports: SWAG (servarr) reaches this by container
             # name over homelab-net, same ingress model as discovery-hermes-oci.
@@ -402,10 +351,22 @@ in {
               # self-hosted STUN reflector, ever, on any relay in this design).
             };
             environmentFiles = [
-              config.sops.secrets."netbird/auth_secret".path
+              "/run/vault-agent/netbird-auth.env"
             ];
             networks = ["homelab-net"];
           };
+        };
+
+        systemd.services.docker-netbird-relay = {
+          after = ["vault-agent.service"];
+          requires = ["vault-agent.service"];
+          serviceConfig.ExecStartPre = pkgs.writeShellScript "wait-for-netbird-auth-env" ''
+            for _ in $(seq 1 100); do
+              [ -s /run/vault-agent/netbird-auth.env ] && exit 0
+              sleep 0.1
+            done
+            exit 1
+          '';
         };
 
         # No host firewall rules here: nothing is published to the host

--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -209,5 +209,5 @@
     "user": "root"
   },
   "source": "modules/hosts/discovery/vault.nix",
-  "source_sha256": "ee2d152a82284aca804af5e496ea79657f453416df59135267c32be61cb60c4e"
+  "source_sha256": "16425ce2a2421fe2439678276464ddd3c7cc594b187db68d13e49c20d269d8fc"
 }

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -304,6 +304,21 @@ in {
             destination = "/run/vault-agent/netbird-pocketid.env"
             perms = "0400"
           }
+          template {
+            contents = "${renderedAt}{{ with secret \"secret/data/home/netbird\" }}{{ .Data.data.POSTGRES_DSN }}\n{{ end }}"
+            destination = "/run/vault-agent/netbird-postgres.env"
+            perms = "0400"
+          }
+          template {
+            contents = "${renderedAt}{{ with secret \"secret/data/home/netbird\" }}{{ .Data.data.AUTH_SECRET }}\n{{ end }}"
+            destination = "/run/vault-agent/netbird-auth.env"
+            perms = "0400"
+          }
+          template {
+            contents = "${renderedAt}{{ with secret \"secret/data/home/netbird\" }}{{ .Data.data.DATASTORE_ENC_KEY }}\n{{ end }}"
+            destination = "/run/vault-agent/netbird-datastore.key"
+            perms = "0400"
+          }
           # Harbor setup and the fixed mirror recipe run as root. Keep the
           # project-scoped robot beside the admin/database inputs without
           # exposing any of them to rootless Compose.

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -155,6 +155,23 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
         self.assertIn("seed-netbird-pocketid-vault:", justfile)
         self.assertIn("verify-netbird-pocketid-secret-render:", justfile)
 
+    def test_netbird_controlplane_secrets_come_from_vault_agent(self):
+        vault = SOURCE.read_text()
+        netbird = (ROOT / "modules/hosts/discovery/netbird-server.nix").read_text()
+        for destination in (
+            "/run/vault-agent/netbird-postgres.env",
+            "/run/vault-agent/netbird-auth.env",
+            "/run/vault-agent/netbird-datastore.key",
+        ):
+            self.assertIn(f'destination = "{destination}"', vault)
+            self.assertIn(destination, netbird)
+        for name in ("postgres_dsn", "auth_secret", "datastore_enc_key"):
+            self.assertNotIn(f'sops.secrets."netbird/{name}"', netbird)
+        self.assertEqual(netbird.count("2>/dev/null || true)"), 2)
+        justfile = JUSTFILE.read_text()
+        self.assertIn("seed-netbird-controlplane-vault:", justfile)
+        self.assertIn("verify-netbird-controlplane-secret-render:", justfile)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- render NetBird DSN, relay HMAC, and datastore key through Vault Agent
- remove their runtime SOPS projections
- preserve bounded fail-closed startup ordering

## Verification
- `python3 tests/discovery-secret-contract/test_vault_surface.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`