### PR TITLE
feat(secrets): move Hermes runtime envs to Vault

### DIFF
--- a/justfile
+++ b/justfile
@@ -2748,6 +2748,74 @@ verify-netbird-controlplane-secret-render:
       echo "netbird_controlplane_render=ready mode=0400 owner=root group=vault-consumers fresh=true files=3"
     '
 
+# Merge encrypted Hermes runtime envs into their Vault document.
+seed-hermes-vault:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    server="$(sops --decrypt --extract '["hermes_agent"]["server_env"]' secrets/sops/secrets.yaml)"
+    daedalus="$(sops --decrypt --extract '["hermes_agents"]["daedalus_env"]' secrets/sops/secrets.yaml)"
+    argus="$(sops --decrypt --extract '["hermes_agents"]["argus_env"]' secrets/sops/secrets.yaml)"
+    test -n "$server" && test -n "$daedalus" && test -n "$argus"
+    token="$(sops --decrypt --extract '["vault_root_token"]' secrets/sops/secrets.yaml)"
+    {
+      printf '%s\n' "$(printf '%s' "$token" | base64 -w0)"
+      jq -cn \
+        --arg server "$server" \
+        --arg daedalus "$daedalus" \
+        --arg argus "$argus" \
+        '{SERVER_ENV:$server,DAEDALUS_ENV:$daedalus,ARGUS_ENV:$argus}' |
+        base64 -w0
+      printf '\n'
+    } | ssh -p 2222 erik@{{ip_discovery}} '
+      set -euo pipefail
+      IFS= read -r token_b64
+      IFS= read -r value_b64
+      header="$(mktemp)"
+      current="$(mktemp)"
+      incoming="$(mktemp)"
+      payload="$(mktemp)"
+      trap "rm -f \"$header\" \"$current\" \"$incoming\" \"$payload\"" EXIT
+      chmod 600 "$header" "$current" "$incoming" "$payload"
+      printf "X-Vault-Token: %s\n" "$(printf "%s" "$token_b64" | base64 --decode)" > "$header"
+      unset token_b64
+      printf "%s" "$value_b64" | base64 --decode > "$incoming"
+      unset value_b64
+      http_status="$(
+        curl --header @"$header" --silent --show-error \
+          --output "$current" --write-out "%{http_code}" \
+          http://127.0.0.1:8200/v1/secret/data/home/hermes
+      )"
+      case "$http_status" in
+        200) ;;
+        404) printf "{\"data\":{\"data\":{}}}" > "$current" ;;
+        *) echo "Hermes Vault read failed: HTTP $http_status" >&2; exit 1 ;;
+      esac
+      jq -s "{data:(.[0].data.data + .[1])}" "$current" "$incoming" > "$payload"
+      curl --header @"$header" --silent --show-error --fail --request POST \
+        --data-binary @"$payload" \
+        http://127.0.0.1:8200/v1/secret/data/home/hermes >/dev/null
+      echo "hermes_vault=seeded keys_added=3"
+    '
+
+# Verify render metadata and consumers without exposing env contents.
+verify-hermes-secret-renders:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP="$(just _host-ip discovery)"
+    ssh -p 2222 erik@"$IP" '
+      set -euo pipefail
+      sudo systemctl is-active vault-agent.service
+      for file in hermes-agent.env hermes-daedalus.env hermes-argus.env; do
+        test "$(sudo stat -c '"'"'%a %U %G'"'"' /run/vault-agent/$file)" = "400 root vault-consumers"
+        sudo find "/run/vault-agent/$file" -mmin -15 -print -quit | grep -q .
+        sudo test -s "/run/vault-agent/$file"
+      done
+      sudo systemctl is-active docker-hermes-agent.service
+      sudo systemctl is-active docker-hermes-daedalus.service
+      sudo systemctl is-active docker-hermes-argus.service
+      echo "hermes_render=ready mode=0400 owner=root group=vault-consumers fresh=true files=3"
+    '
+
 # Prove the critical infra render is fresh and least-privilege without printing it.
 verify-infra-secret-render:
     #!/usr/bin/env bash

--- a/modules/hosts/discovery/_vault-agent.nix
+++ b/modules/hosts/discovery/_vault-agent.nix
@@ -150,6 +150,21 @@ in {
           perms = "0400"
         }
         template {
+          contents = "{{ with secret \"secret/data/home/hermes\" }}{{ .Data.data.SERVER_ENV }}\n{{ end }}"
+          destination = "/run/vault-agent/hermes-agent.env"
+          perms = "0400"
+        }
+        template {
+          contents = "{{ with secret \"secret/data/home/hermes\" }}{{ .Data.data.DAEDALUS_ENV }}\n{{ end }}"
+          destination = "/run/vault-agent/hermes-daedalus.env"
+          perms = "0400"
+        }
+        template {
+          contents = "{{ with secret \"secret/data/home/hermes\" }}{{ .Data.data.ARGUS_ENV }}\n{{ end }}"
+          destination = "/run/vault-agent/hermes-argus.env"
+          perms = "0400"
+        }
+        template {
           contents = "{{ with secret \"secret/data/home/infra\" }}MINIO_TFSTATE_ROOT_PASSWORD={{ .Data.data.MINIO_TFSTATE_ROOT_PASSWORD }}\nVAULTWARDEN_ADMIN_TOKEN={{ .Data.data.VAULTWARDEN_ADMIN_TOKEN }}\nVAULT_DEV_ROOT_TOKEN={{ .Data.data.VAULT_DEV_ROOT_TOKEN }}\n{{ end }}"
           destination = "/run/vault-agent/infra.env"
           perms = "0440"

--- a/modules/hosts/discovery/hermes-agents.nix
+++ b/modules/hosts/discovery/hermes-agents.nix
@@ -1,7 +1,6 @@
 {
   config,
   inputs,
-  self,
   ...
 }: let
   inherit (config) username;
@@ -9,6 +8,7 @@ in {
   flake.modules.nixos.discovery-hermes-agents = {
     config,
     lib,
+    pkgs,
     ...
   }: let
     litellmUrl = "http://litellm:4000/v1";
@@ -83,27 +83,12 @@ in {
       }
     ];
 
-    sops.secrets."hermes_agents/daedalus_env" = {
-      sopsFile = self + "/secrets/sops/secrets.yaml";
-      key = "hermes_agents/daedalus_env";
-      mode = "0400";
-      path = "/run/secrets/hermes-daedalus";
-      restartUnits = ["docker-hermes-daedalus.service"];
-    };
-    sops.secrets."hermes_agents/argus_env" = {
-      sopsFile = self + "/secrets/sops/secrets.yaml";
-      key = "hermes_agents/argus_env";
-      mode = "0400";
-      path = "/run/secrets/hermes-argus";
-      restartUnits = ["docker-hermes-argus.service"];
-    };
-
     services.hermes-agent-oci-daedalus = {
       enable = true;
       enableHealthcheck = false;
       image = "nousresearch/hermes-agent@sha256:229429fe176efa05ca4e542a7e11348482b40c36f903191498c7016f1dfc1019";
       hostDataDir = "/home/${username}/homelab/apps/hermes-daedalus";
-      environmentFile = config.sops.secrets."hermes_agents/daedalus_env".path;
+      environmentFile = "/run/vault-agent/hermes-daedalus.env";
       openBindAddress = "0.0.0.0";
       publishPorts = false;
       openaiBaseUrl = litellmUrl;
@@ -154,7 +139,7 @@ in {
       enableHealthcheck = false;
       image = "nousresearch/hermes-agent@sha256:229429fe176efa05ca4e542a7e11348482b40c36f903191498c7016f1dfc1019";
       hostDataDir = "/home/${username}/homelab/apps/hermes-argus";
-      environmentFile = config.sops.secrets."hermes_agents/argus_env".path;
+      environmentFile = "/run/vault-agent/hermes-argus.env";
       openBindAddress = "0.0.0.0";
       publishPorts = false;
       openaiBaseUrl = litellmUrl;
@@ -203,6 +188,30 @@ in {
           '';
         };
       };
+    };
+
+    systemd.services.docker-hermes-daedalus = {
+      after = ["vault-agent.service"];
+      requires = ["vault-agent.service"];
+      serviceConfig.ExecStartPre = pkgs.writeShellScript "wait-for-hermes-daedalus-env" ''
+        for _ in $(seq 1 100); do
+          [ -s /run/vault-agent/hermes-daedalus.env ] && exit 0
+          sleep 0.1
+        done
+        exit 1
+      '';
+    };
+
+    systemd.services.docker-hermes-argus = {
+      after = ["vault-agent.service"];
+      requires = ["vault-agent.service"];
+      serviceConfig.ExecStartPre = pkgs.writeShellScript "wait-for-hermes-argus-env" ''
+        for _ in $(seq 1 100); do
+          [ -s /run/vault-agent/hermes-argus.env ] && exit 0
+          sleep 0.1
+        done
+        exit 1
+      '';
     };
   };
 }

--- a/modules/hosts/discovery/hermes-oci.nix
+++ b/modules/hosts/discovery/hermes-oci.nix
@@ -1,7 +1,6 @@
 {
   config,
   inputs,
-  self,
   ...
 }: let
   inherit (config) username; # flake-parts top-level options (meta.nix)
@@ -46,22 +45,13 @@ in {
       }
     ];
 
-    # sops dotenv with UPSTREAM-BARE names (no HERMES_ bridge on the OCI path):
+    # Vault-rendered dotenv with UPSTREAM-BARE names (no HERMES_ bridge on the OCI path):
     # OPENAI_API_KEY, API_SERVER_KEY, TELEGRAM_BOT_TOKEN, DISCORD_BOT_TOKEN,
     # EXA_API_KEY. Read by the docker daemon (root) at container start.
     # NOTE (cutover pre-step): the existing secret carries the namespaced
     # HERMES_TELEGRAM_BOT_TOKEN / HERMES_DISCORD_BOT_TOKEN (the compose remapped
     # them); add the bare TELEGRAM_BOT_TOKEN / DISCORD_BOT_TOKEN before switch or
     # Telegram/Discord stay silent. See the cutover runbook.
-    sops.secrets."hermes_agent/server_env" = {
-      sopsFile = self + "/secrets/sops/secrets.yaml";
-      format = "yaml";
-      key = "hermes_agent/server_env";
-      mode = "0400";
-      path = "/run/secrets/hermes-agent";
-      restartUnits = ["docker-hermes-agent.service"];
-    };
-
     services.hermes-agent-oci = {
       enable = true;
       enableHealthcheck = false;
@@ -73,7 +63,7 @@ in {
       # Reuse the existing live state dir (restic-backed btrfs subvol):
       # memories, sessions, skills, lazy venv survive the Docker→OCI swap.
       hostDataDir = "/home/${username}/homelab/apps/hermes-agent";
-      environmentFile = config.sops.secrets."hermes_agent/server_env".path;
+      environmentFile = "/run/vault-agent/hermes-agent.env";
 
       # Container binds 0.0.0.0 (API_SERVER_HOST) so SWAG + litellm reach it
       # over homelab-net by name — but do NOT publish to the host (publishPorts
@@ -224,6 +214,18 @@ in {
           };
         };
       };
+    };
+
+    systemd.services.docker-hermes-agent = {
+      after = ["vault-agent.service"];
+      requires = ["vault-agent.service"];
+      serviceConfig.ExecStartPre = pkgs.writeShellScript "wait-for-hermes-agent-env" ''
+        for _ in $(seq 1 100); do
+          [ -s /run/vault-agent/hermes-agent.env ] && exit 0
+          sleep 0.1
+        done
+        exit 1
+      '';
     };
 
     # No host firewall rules here: ports aren't published to the host

--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -209,5 +209,5 @@
     "user": "root"
   },
   "source": "modules/hosts/discovery/vault.nix",
-  "source_sha256": "16425ce2a2421fe2439678276464ddd3c7cc594b187db68d13e49c20d269d8fc"
+  "source_sha256": "2df401e45213e84939ca7bbf4d4907c9403c9cbe42039c7e6d6189fa3a5c363b"
 }

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -319,6 +319,21 @@ in {
             destination = "/run/vault-agent/netbird-datastore.key"
             perms = "0400"
           }
+          template {
+            contents = "${renderedAt}{{ with secret \"secret/data/home/hermes\" }}{{ .Data.data.SERVER_ENV }}\n{{ end }}"
+            destination = "/run/vault-agent/hermes-agent.env"
+            perms = "0400"
+          }
+          template {
+            contents = "${renderedAt}{{ with secret \"secret/data/home/hermes\" }}{{ .Data.data.DAEDALUS_ENV }}\n{{ end }}"
+            destination = "/run/vault-agent/hermes-daedalus.env"
+            perms = "0400"
+          }
+          template {
+            contents = "${renderedAt}{{ with secret \"secret/data/home/hermes\" }}{{ .Data.data.ARGUS_ENV }}\n{{ end }}"
+            destination = "/run/vault-agent/hermes-argus.env"
+            perms = "0400"
+          }
           # Harbor setup and the fixed mirror recipe run as root. Keep the
           # project-scoped robot beside the admin/database inputs without
           # exposing any of them to rootless Compose.

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -172,6 +172,26 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
         self.assertIn("seed-netbird-controlplane-vault:", justfile)
         self.assertIn("verify-netbird-controlplane-secret-render:", justfile)
 
+    def test_hermes_runtime_envs_come_from_vault_agent(self):
+        vault = SOURCE.read_text()
+        primary = (ROOT / "modules/hosts/discovery/hermes-oci.nix").read_text()
+        agents = (ROOT / "modules/hosts/discovery/hermes-agents.nix").read_text()
+        for destination in (
+            "/run/vault-agent/hermes-agent.env",
+            "/run/vault-agent/hermes-daedalus.env",
+            "/run/vault-agent/hermes-argus.env",
+        ):
+            self.assertIn(f'destination = "{destination}"', vault)
+        self.assertIn('environmentFile = "/run/vault-agent/hermes-agent.env"', primary)
+        self.assertIn('environmentFile = "/run/vault-agent/hermes-daedalus.env"', agents)
+        self.assertIn('environmentFile = "/run/vault-agent/hermes-argus.env"', agents)
+        self.assertNotIn('sops.secrets."hermes_agent/server_env"', primary)
+        self.assertNotIn('sops.secrets."hermes_agents/daedalus_env"', agents)
+        self.assertNotIn('sops.secrets."hermes_agents/argus_env"', agents)
+        justfile = JUSTFILE.read_text()
+        self.assertIn("seed-hermes-vault:", justfile)
+        self.assertIn("verify-hermes-secret-renders:", justfile)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- render Discovery Hermes runtime envs through Vault Agent
- remove the three runtime SOPS projections
- order container startup after fresh renders

## Verification
- `python3 tests/discovery-secret-contract/test_vault_surface.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`