### PR TITLE
feat(secrets): move Hermes wiki key to Vault

### DIFF
--- a/justfile
+++ b/justfile
@@ -2755,7 +2755,8 @@ seed-hermes-vault:
     server="$(sops --decrypt --extract '["hermes_agent"]["server_env"]' secrets/sops/secrets.yaml)"
     daedalus="$(sops --decrypt --extract '["hermes_agents"]["daedalus_env"]' secrets/sops/secrets.yaml)"
     argus="$(sops --decrypt --extract '["hermes_agents"]["argus_env"]' secrets/sops/secrets.yaml)"
-    test -n "$server" && test -n "$daedalus" && test -n "$argus"
+    wiki="$(sops --decrypt --extract '["hermes_wiki"]["deploy_key"]' secrets/sops/secrets.yaml)"
+    test -n "$server" && test -n "$daedalus" && test -n "$argus" && test -n "$wiki"
     token="$(sops --decrypt --extract '["vault_root_token"]' secrets/sops/secrets.yaml)"
     {
       printf '%s\n' "$(printf '%s' "$token" | base64 -w0)"
@@ -2763,7 +2764,8 @@ seed-hermes-vault:
         --arg server "$server" \
         --arg daedalus "$daedalus" \
         --arg argus "$argus" \
-        '{SERVER_ENV:$server,DAEDALUS_ENV:$daedalus,ARGUS_ENV:$argus}' |
+        --arg wiki "$wiki" \
+        '{SERVER_ENV:$server,DAEDALUS_ENV:$daedalus,ARGUS_ENV:$argus,WIKI_DEPLOY_KEY:$wiki}' |
         base64 -w0
       printf '\n'
     } | ssh -p 2222 erik@{{ip_discovery}} '
@@ -2774,8 +2776,9 @@ seed-hermes-vault:
       current="$(mktemp)"
       incoming="$(mktemp)"
       payload="$(mktemp)"
-      trap "rm -f \"$header\" \"$current\" \"$incoming\" \"$payload\"" EXIT
-      chmod 600 "$header" "$current" "$incoming" "$payload"
+      key="$(mktemp)"
+      trap "rm -f \"$header\" \"$current\" \"$incoming\" \"$payload\" \"$key\"" EXIT
+      chmod 600 "$header" "$current" "$incoming" "$payload" "$key"
       printf "X-Vault-Token: %s\n" "$(printf "%s" "$token_b64" | base64 --decode)" > "$header"
       unset token_b64
       printf "%s" "$value_b64" | base64 --decode > "$incoming"
@@ -2794,7 +2797,14 @@ seed-hermes-vault:
       curl --header @"$header" --silent --show-error --fail --request POST \
         --data-binary @"$payload" \
         http://127.0.0.1:8200/v1/secret/data/home/hermes >/dev/null
-      echo "hermes_vault=seeded keys_added=3"
+      expected="$(jq -r .WIKI_DEPLOY_KEY "$incoming" | sha256sum | cut -d" " -f1)"
+      curl --header @"$header" --silent --show-error --fail \
+        http://127.0.0.1:8200/v1/secret/data/home/hermes > "$current"
+      jq -r .data.data.WIKI_DEPLOY_KEY "$current" > "$key"
+      actual="$(sha256sum "$key" | cut -d" " -f1)"
+      test "$actual" = "$expected"
+      ssh-keygen -y -f "$key" >/dev/null
+      echo "hermes_vault=seeded keys_added=4"
     '
 
 # Verify render metadata and consumers without exposing env contents.
@@ -2810,11 +2820,16 @@ verify-hermes-secret-renders:
         sudo find "/run/vault-agent/$file" -mmin -15 -print -quit | grep -q .
         sudo test -s "/run/vault-agent/$file"
       done
+      test "$(sudo stat -c '"'"'%a %U %G'"'"' /run/vault-agent/hermes-wiki.key)" = "400 hermes hermes"
+      sudo find /run/vault-agent/hermes-wiki.key -mmin -15 -print -quit | grep -q .
+      sudo test -s /run/vault-agent/hermes-wiki.key
       sudo systemctl is-active docker-hermes-agent.service
       sudo systemctl is-active docker-hermes-daedalus.service
       sudo systemctl is-active docker-hermes-argus.service
-      echo "hermes_render=ready mode=0400 owner=root group=vault-consumers fresh=true files=3"
+      sudo systemctl is-active hermes-wiki-clone.service
+      echo "hermes_render=ready mode=0400 fresh=true files=4 wiki_owner=hermes"
     '
+
 
 # Prove the critical infra render is fresh and least-privilege without printing it.
 verify-infra-secret-render:

--- a/modules/hosts/discovery/_vault-agent.nix
+++ b/modules/hosts/discovery/_vault-agent.nix
@@ -165,6 +165,14 @@ in {
           perms = "0400"
         }
         template {
+          contents = "{{ with secret \"secret/data/home/hermes\" }}{{ .Data.data.WIKI_DEPLOY_KEY }}{{ end }}\n"
+          destination = "/run/vault-agent/hermes-wiki.key"
+          perms = "0400"
+          exec {
+            command = ["${pkgs.coreutils}/bin/chown", "hermes:hermes", "/run/vault-agent/hermes-wiki.key"]
+          }
+        }
+        template {
           contents = "{{ with secret \"secret/data/home/infra\" }}MINIO_TFSTATE_ROOT_PASSWORD={{ .Data.data.MINIO_TFSTATE_ROOT_PASSWORD }}\nVAULTWARDEN_ADMIN_TOKEN={{ .Data.data.VAULTWARDEN_ADMIN_TOKEN }}\nVAULT_DEV_ROOT_TOKEN={{ .Data.data.VAULT_DEV_ROOT_TOKEN }}\n{{ end }}"
           destination = "/run/vault-agent/infra.env"
           perms = "0440"

--- a/modules/hosts/discovery/hermes-oci.nix
+++ b/modules/hosts/discovery/hermes-oci.nix
@@ -97,7 +97,7 @@ in {
         # longer manual host state. git ssh is scoped to this repo via
         # core.sshCommand (set by the clone oneshot, points at /opt/wiki-key).
         "/var/lib/hermes-wiki:/opt/wiki:rw"
-        ''${config.sops.secrets."hermes_wiki/deploy_key".path}:/opt/wiki-key:ro''
+        "/run/vault-agent/hermes-wiki.key:/opt/wiki-key:ro"
       ];
 
       extraEnvironment = {

--- a/modules/hosts/discovery/hermes-wiki.nix
+++ b/modules/hosts/discovery/hermes-wiki.nix
@@ -1,6 +1,6 @@
-{self, ...}: {
+_: {
   # Declarative bootstrap for the native hermes LLM wiki: materialize the
-  # vault.git-scoped deploy key from sops, clone vault.git @ `hermes` branch, and
+  # vault.git-scoped deploy key from Vault Agent, clone vault.git @ `hermes` branch, and
   # seed the daily `wiki-consolidate` cron job — so the whole wiki survives a
   # reprovision / state wipe (previously all manual host state). See
   # docs/hermes-llm-wiki.md.
@@ -11,7 +11,7 @@
     ...
   }: let
     wikiDir = "/var/lib/hermes-wiki";
-    keyPath = config.sops.secrets."hermes_wiki/deploy_key".path;
+    keyPath = "/run/vault-agent/hermes-wiki.key";
 
     cronPrompt = ''
       Daily wiki consolidation. Your cwd is /opt/wiki — the LLM wiki (git checkout on the `hermes` branch); schema/ops in ./AGENTS.md.
@@ -58,24 +58,16 @@
       '';
     };
   in {
-    # Host user matching the container's internal uid/gid so sops can own the
+    # Host user matching the container's internal uid/gid so Vault Agent can own the
     # key and the clone, and the clone oneshot can run as it.
     users.groups.hermes.gid = lib.mkDefault 10000;
     users.users.hermes = {
       isSystemUser = true;
       group = "hermes";
+      extraGroups = ["vault-consumers"];
       uid = lib.mkDefault 10000;
       home = wikiDir;
       createHome = false;
-    };
-
-    sops.secrets."hermes_wiki/deploy_key" = {
-      sopsFile = self + "/secrets/sops/secrets.yaml";
-      key = "hermes_wiki/deploy_key";
-      owner = "hermes";
-      group = "hermes";
-      mode = "0400";
-      restartUnits = ["hermes-wiki-clone.service"];
     };
 
     systemd.tmpfiles.rules = [
@@ -90,7 +82,8 @@
       # nss-lookup.target for DNS; but network-online.target still fires before
       # the default route is actually usable on this host (seen at boot:
       # "ssh: connect to github.com port 22: Network is unreachable"), so retry.
-      after = ["network-online.target" "nss-lookup.target" "sops-nix.service"];
+      after = ["network-online.target" "nss-lookup.target" "vault-agent.service"];
+      requires = ["vault-agent.service"];
       wants = ["network-online.target" "nss-lookup.target"];
       path = [pkgs.git pkgs.openssh pkgs.coreutils];
       # Boot network race: the github clone runs before routing is up on a cold
@@ -105,6 +98,13 @@
         RemainAfterExit = true;
         Restart = "on-failure";
         RestartSec = "15s";
+        ExecStartPre = pkgs.writeShellScript "wait-for-hermes-wiki-key" ''
+          for _ in $(seq 1 100); do
+            [ -s ${keyPath} ] && [ -r ${keyPath} ] && exit 0
+            sleep 0.1
+          done
+          exit 1
+        '';
       };
       script = ''
         set -euo pipefail

--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -209,5 +209,5 @@
     "user": "root"
   },
   "source": "modules/hosts/discovery/vault.nix",
-  "source_sha256": "2df401e45213e84939ca7bbf4d4907c9403c9cbe42039c7e6d6189fa3a5c363b"
+  "source_sha256": "418078ea09957bb8063d143d5b3efc786f407fe8b0005fd6863ae86146a6b8e9"
 }

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -334,6 +334,14 @@ in {
             destination = "/run/vault-agent/hermes-argus.env"
             perms = "0400"
           }
+          template {
+            contents = "{{ with secret \"secret/data/home/hermes\" }}{{ .Data.data.WIKI_DEPLOY_KEY }}{{ end }}\n"
+            destination = "/run/vault-agent/hermes-wiki.key"
+            perms = "0400"
+            exec {
+              command = ["${pkgs.coreutils}/bin/chown", "hermes:hermes", "/run/vault-agent/hermes-wiki.key"]
+            }
+          }
           # Harbor setup and the fixed mirror recipe run as root. Keep the
           # project-scoped robot beside the admin/database inputs without
           # exposing any of them to rootless Compose.

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -192,6 +192,19 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
         self.assertIn("seed-hermes-vault:", justfile)
         self.assertIn("verify-hermes-secret-renders:", justfile)
 
+    def test_hermes_wiki_deploy_key_comes_from_vault_agent(self):
+        vault = SOURCE.read_text()
+        wiki = (ROOT / "modules/hosts/discovery/hermes-wiki.nix").read_text()
+        primary = (ROOT / "modules/hosts/discovery/hermes-oci.nix").read_text()
+        self.assertIn('destination = "/run/vault-agent/hermes-wiki.key"', vault)
+        self.assertIn('.Data.data.WIKI_DEPLOY_KEY }}{{ end }}\\n"', vault)
+        self.assertIn('"/run/vault-agent/hermes-wiki.key:/opt/wiki-key:ro"', primary)
+        self.assertIn('keyPath = "/run/vault-agent/hermes-wiki.key"', wiki)
+        self.assertIn('extraGroups = ["vault-consumers"]', wiki)
+        self.assertNotIn('sops.secrets."hermes_wiki/deploy_key"', wiki)
+        self.assertIn('after = ["network-online.target" "nss-lookup.target" "vault-agent.service"]', wiki)
+        self.assertIn('[ -s ${keyPath} ] && [ -r ${keyPath} ]', wiki)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- render the Hermes wiki deploy key through Vault Agent
- remove its runtime SOPS projection
- keep clone and container startup ordered after the render

## Verification
- `python3 tests/discovery-secret-contract/test_vault_surface.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`