### PR TITLE
fix(vault): provide shell to restore drill

### DIFF
--- a/justfile
+++ b/justfile
@@ -2833,6 +2833,9 @@ verify-hermes-secret-renders:
 openbao-restore-drill:
     IP="$(just _host-ip discovery)"; ssh -p 2222 erik@"$IP" 'sudo systemctl start openbao-restore-drill.service && sudo systemctl status openbao-restore-drill.service --no-pager'
 
+openbao-restore-drill-diagnose:
+    IP="$(just _host-ip discovery)"; ssh -p 2222 erik@"$IP" 'sudo systemctl status openbao-restore-drill.service --no-pager -l || true; sudo journalctl -u openbao-restore-drill.service --no-pager -n 100'
+
 
 # Prove the critical infra render is fresh and least-privilege without printing it.
 verify-infra-secret-render:

--- a/modules/hosts/discovery/vault-env-contract.json
+++ b/modules/hosts/discovery/vault-env-contract.json
@@ -209,5 +209,5 @@
     "user": "root"
   },
   "source": "modules/hosts/discovery/vault.nix",
-  "source_sha256": "56750886e09b3a41736f0fe6cf39334a6e54583cd9d6242d40eb8d57befff0f3"
+  "source_sha256": "602a29e9b8d52e6f1779cd4e3b59b16c514f56fc12614519e4782008cd449d85"
 }

--- a/modules/hosts/discovery/vault.nix
+++ b/modules/hosts/discovery/vault.nix
@@ -526,6 +526,7 @@ in {
     # drill ports keep this path physically separate from :8200 production.
     systemd.services.openbao-restore-drill = {
       description = "Verify OpenBao snapshot restore in an isolated raft node";
+      path = [pkgs.bash];
       serviceConfig = {
         Type = "oneshot";
         PrivateTmp = true;

--- a/tests/discovery-secret-contract/test_vault_surface.py
+++ b/tests/discovery-secret-contract/test_vault_surface.py
@@ -209,6 +209,10 @@ class DiscoveryVaultSurfaceTest(unittest.TestCase):
         vault = SOURCE.read_text()
         justfile = JUSTFILE.read_text()
         self.assertIn("systemd.services.openbao-restore-drill", vault)
+        drill = vault.split("systemd.services.openbao-restore-drill", 1)[1].split(
+            "systemd.timers.openbao-restore-drill", 1
+        )[0]
+        self.assertIn("path = [pkgs.bash]", drill)
         self.assertIn("127.0.0.1:18200", vault)
         self.assertIn("mktemp -d /var/tmp/openbao-restore-drill.", vault)
         self.assertIn("operator raft snapshot restore -force", vault)


### PR DESCRIPTION
OpenBao CLI resolves its token helper through sh. Add bash to the isolated drill unit PATH and retain a value-free diagnostic recipe.\n\nVerified: red/green contract test, lint, fmt-check, just dry discovery.