### PR TITLE
fix(secrets): source LiteLLM key for monitoring

### DIFF
--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -8,7 +8,7 @@ _: {
       # gets a second --env-file /run/vault-agent/<stack>.env (see orchestration.nix).
       vaultEnvStacks = {
         tunneling = ["tunneling"];
-        monitoring = ["monitoring" "shared-grafana"];
+        monitoring = ["monitoring" "shared-grafana" "ai-serving"];
         tools = ["tools"];
         media = ["media" "shared-arr"];
         networking = ["networking"];

--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -37,6 +37,7 @@ _: {
       secretSpecRuntimeHealthContainers."media-server" = ["jellystat"];
       secretSpecRuntimeProfiles.monitoring = "monitoring";
       secretSpecRuntimeSourceConfigNames.monitoring = ["GRAFANA_ADMIN_USER"];
+      secretSpecRuntimeIgnoredSourceNames.monitoring = ["CLICKHOUSE_PASSWORD" "LANGFUSE_INIT_USER_PASSWORD" "LANGFUSE_PUBLIC_KEY" "LANGFUSE_SALT" "LANGFUSE_SECRET_KEY" "LITELLM_SALT_KEY" "MINIO_ROOT_PASSWORD" "OPENCODE_GO_KEY" "OPENCODE_ZEN_KEY" "UI_PASSWORD"];
       secretSpecRuntimeHealthContainers.monitoring = ["grafana" "healthchecks" "scrutiny-influxdb" "scrutiny"];
       secretSpecRuntimeProfiles.media = "media";
       secretSpecRuntimeSourceConfigNames.media = ["NORDVPN_USER" "QBITTORRENT_USER"];

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -178,6 +178,10 @@ class RuntimeProjectionTest(unittest.TestCase):
             'secretSpecRuntimeSourceConfigNames.monitoring = ["GRAFANA_ADMIN_USER"];',
             source,
         )
+        self.assertIn(
+            'secretSpecRuntimeIgnoredSourceNames.monitoring = ["CLICKHOUSE_PASSWORD" "LANGFUSE_INIT_USER_PASSWORD" "LANGFUSE_PUBLIC_KEY" "LANGFUSE_SALT" "LANGFUSE_SECRET_KEY" "LITELLM_SALT_KEY" "MINIO_ROOT_PASSWORD" "OPENCODE_GO_KEY" "OPENCODE_ZEN_KEY" "UI_PASSWORD"];',
+            source,
+        )
 
     def test_remaining_noncritical_profiles_cut_over_as_one_wave(self):
         source = COMPOSE.read_text()

--- a/tests/discovery-secret-contract/test_runtime_projection.py
+++ b/tests/discovery-secret-contract/test_runtime_projection.py
@@ -172,6 +172,7 @@ class RuntimeProjectionTest(unittest.TestCase):
 
     def test_monitoring_gates_all_secret_consumers(self):
         source = COMPOSE.read_text()
+        self.assertIn('monitoring = ["monitoring" "shared-grafana" "ai-serving"];', source)
         self.assertIn('secretSpecRuntimeProfiles.monitoring = "monitoring";', source)
         self.assertIn(
             'secretSpecRuntimeSourceConfigNames.monitoring = ["GRAFANA_ADMIN_USER"];',


### PR DESCRIPTION
## Summary
- layer the existing `ai-serving.env` Vault render into monitoring projection
- restore Prometheus LiteLLM metrics secret after stack recreation

## Verification
- red/green runtime projection contract
- 17 runtime projection tests
- `just lint`
- `just fmt-check`
- `just dry discovery`