### PR TITLE
fix(monitoring): restore container labels

### DIFF
--- a/justfile
+++ b/justfile
@@ -3177,6 +3177,18 @@ verify-k3s-observability:
     printf '%s\n' "$response" | jq -c '.data.result[]? | {instance: .metric.instance, value: .value[1]}'
     test "$(printf '%s\n' "$response" | jq '[.data.result[]? | select(.value[1] == "1")] | length')" -eq 3
 
+# Prove every compose host exports cAdvisor series with container names.
+verify-container-metrics:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    response=$(curl --fail --silent --show-error --get http://discovery:9090/api/v1/query \
+      --data-urlencode 'query=container_last_seen{name!=""}')
+    for host in discovery kepler orion; do
+      count=$(printf '%s\n' "$response" | jq --arg host '[.data.result[]? | select(.metric.host == $host)] | length')
+      printf '%s named_containers=%s\n' "$host" "$count"
+      test "$count" -gt 0
+    done
+
 # Read-only proof that cp-1's timer last reconciled both bootstrap Secrets.
 verify-k3s-bootstrap:
     #!/usr/bin/env bash

--- a/modules/hosts/discovery/default.nix
+++ b/modules/hosts/discovery/default.nix
@@ -25,6 +25,7 @@ in {
       m.nixos.discovery-haos
       m.nixos.first-boot
       m.nixos.alloy
+      m.nixos.alloy-containers
       m.nixos.kepler-nfs
       m.nixos.discovery-containers
       m.nixos.discovery-compose
@@ -58,6 +59,11 @@ in {
       # S/O are human-gated — see the implementation plan).
       m.nixos.discovery-netbird-server
     ];
+
+    homelab.alloy = {
+      containerSocket = "unix:///run/docker.sock";
+      containerSocketGroup = "docker";
+    };
 
     # NetBird IdP bring-up (RFC docs/proposals/2026-07-11-pocketid-idp-for-netbird.md
     # §6 step 3): idpOnly starts ONLY PocketID + its one sops secret — the IdP that

--- a/modules/services/alloy-containers.nix
+++ b/modules/services/alloy-containers.nix
@@ -2,8 +2,15 @@ _: {
   flake.modules.nixos.alloy-containers = {
     lib,
     config,
+    pkgs,
     ...
-  }: {
+  }: let
+    cfg = config.homelab.alloy;
+    socketPath = lib.removePrefix "unix://" cfg.containerSocket;
+    socketDir = builtins.dirOf socketPath;
+    runtimeDir = builtins.dirOf socketDir;
+    rootlessSocket = lib.hasPrefix "/run/user/" socketPath;
+  in {
     options.homelab.alloy.containerSocket = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;
@@ -16,14 +23,25 @@ _: {
       '';
     };
 
-    config = lib.mkIf (config.homelab.alloy.containerSocket != null) {
+    options.homelab.alloy.containerSocketGroup = lib.mkOption {
+      type = lib.types.str;
+      default = "users";
+      description = "Group allowed to read the configured container runtime socket.";
+    };
+
+    config = lib.mkIf (cfg.containerSocket != null) {
       # Grant the alloy service read access to the rootless Podman socket.
       # The upstream module sets SupplementaryGroups = ["systemd-journal"]; NixOS
       # merges list-valued serviceConfig entries across module definitions, so this
       # appends "users" without dropping "systemd-journal". The socket is mode 660
       # owned by erik:users, and alloy runs DynamicUser=yes — without this group
       # the cadvisor exporter gets EACCES on /run/user/1000/podman/podman.sock.
-      systemd.services.alloy.serviceConfig.SupplementaryGroups = ["users"];
+      systemd.services.alloy.serviceConfig = {
+        SupplementaryGroups = [cfg.containerSocketGroup];
+        ExecStartPre = lib.optionals rootlessSocket [
+          "+${pkgs.acl}/bin/setfacl -m g:${cfg.containerSocketGroup}:--x ${runtimeDir} ${socketDir}"
+        ];
+      };
 
       # Second Alloy config file in the same /etc/alloy dir. The upstream module
       # loads every *.alloy file in configPath (default /etc/alloy) and merges
@@ -36,14 +54,22 @@ _: {
         // Container metrics via cAdvisor exporter (host add-on; see
         // modules/services/alloy-containers.nix). Replaces a cAdvisor sidecar.
         prometheus.exporter.cadvisor "containers" {
-          docker_host            = "${config.homelab.alloy.containerSocket}"
+          docker_host            = "${cfg.containerSocket}"
           store_container_labels = true
         }
 
         prometheus.scrape "container_metrics" {
           targets         = prometheus.exporter.cadvisor.containers.targets
-          forward_to      = [prometheus.remote_write.prometheus.receiver]
+          forward_to      = [prometheus.relabel.container_host.receiver]
           scrape_interval = "30s"
+        }
+
+        prometheus.relabel "container_host" {
+          rule {
+            target_label = "host"
+            replacement  = "${config.networking.hostName}"
+          }
+          forward_to = [prometheus.remote_write.prometheus.receiver]
         }
       '';
     };

--- a/tests/alloy-containers/test_alloy_containers.py
+++ b/tests/alloy-containers/test_alloy_containers.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+MODULE = ROOT / "modules/services/alloy-containers.nix"
+DISCOVERY = ROOT / "modules/hosts/discovery/default.nix"
+JUSTFILE = ROOT / "justfile"
+
+
+def test_container_metrics_cover_rootless_podman_and_docker():
+    module = MODULE.read_text()
+    discovery = DISCOVERY.read_text()
+
+    assert "containerSocketGroup" in module
+    assert "setfacl" in module
+    assert 'target_label = "host"' in module
+    assert "m.nixos.alloy-containers" in discovery
+    assert 'containerSocket = "unix:///run/docker.sock"' in discovery
+    assert 'containerSocketGroup = "docker"' in discovery
+
+
+def test_container_name_labels_have_a_live_verification_recipe():
+    recipe = JUSTFILE.read_text()
+
+    assert "verify-container-metrics:" in recipe
+    assert 'container_last_seen{name!=""}' in recipe
+    for host in ("discovery", "kepler", "orion"):
+        assert host in recipe


### PR DESCRIPTION
## Summary
- grant host Alloy access through rootless Podman runtime directories
- make the socket group configurable and reuse the cAdvisor module for Discovery Docker
- attach an explicit host label and add a live verification recipe

## Verification
- `pytest -q tests/alloy-containers/test_alloy_containers.py`
- `just lint`
- `just fmt-check`
- `just dry discovery`
- `just dry kepler`
- `just dry orion`