### PR TITLE
fix(monitoring): grant cAdvisor host access

### DIFF
--- a/justfile
+++ b/justfile
@@ -3184,10 +3184,15 @@ verify-container-metrics:
     response=$(curl --fail --silent --show-error --get http://discovery:9090/api/v1/query \
       --data-urlencode 'query=container_last_seen{name!=""}')
     for host in discovery kepler orion; do
-      count=$(printf '%s\n' "$response" | jq --arg host '[.data.result[]? | select(.metric.host == $host)] | length')
+      count=$(printf '%s\n' "$response" | jq --arg host "$host" '[.data.result[]? | select(.metric.host == $host)] | length')
       printf '%s named_containers=%s\n' "$host" "$count"
       test "$count" -gt 0
     done
+
+# Inspect the host collector when container metrics verification fails.
+diagnose-container-metrics host:
+    ssh -p 2222 erik@{{host}} \
+      "systemctl status alloy --no-pager -n 20; journalctl -u alloy --since '-10 minutes' --no-pager -n 100"
 
 # Read-only proof that cp-1's timer last reconciled both bootstrap Secrets.
 verify-k3s-bootstrap:

--- a/modules/hosts/discovery/default.nix
+++ b/modules/hosts/discovery/default.nix
@@ -62,7 +62,6 @@ in {
 
     homelab.alloy = {
       containerSocket = "unix:///run/docker.sock";
-      containerSocketGroup = "docker";
     };
 
     # NetBird IdP bring-up (RFC docs/proposals/2026-07-11-pocketid-idp-for-netbird.md

--- a/modules/services/alloy-containers.nix
+++ b/modules/services/alloy-containers.nix
@@ -2,14 +2,9 @@ _: {
   flake.modules.nixos.alloy-containers = {
     lib,
     config,
-    pkgs,
     ...
   }: let
     cfg = config.homelab.alloy;
-    socketPath = lib.removePrefix "unix://" cfg.containerSocket;
-    socketDir = builtins.dirOf socketPath;
-    runtimeDir = builtins.dirOf socketDir;
-    rootlessSocket = lib.hasPrefix "/run/user/" socketPath;
   in {
     options.homelab.alloy.containerSocket = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
@@ -23,24 +18,13 @@ _: {
       '';
     };
 
-    options.homelab.alloy.containerSocketGroup = lib.mkOption {
-      type = lib.types.str;
-      default = "users";
-      description = "Group allowed to read the configured container runtime socket.";
-    };
-
     config = lib.mkIf (cfg.containerSocket != null) {
-      # Grant the alloy service read access to the rootless Podman socket.
-      # The upstream module sets SupplementaryGroups = ["systemd-journal"]; NixOS
-      # merges list-valued serviceConfig entries across module definitions, so this
-      # appends "users" without dropping "systemd-journal". The socket is mode 660
-      # owned by erik:users, and alloy runs DynamicUser=yes — without this group
-      # the cadvisor exporter gets EACCES on /run/user/1000/podman/podman.sock.
+      # cAdvisor inspects runtime sockets, cgroups, and container storage metadata.
+      # A DynamicUser can reach the socket but cannot read rootless Podman storage.
       systemd.services.alloy.serviceConfig = {
-        SupplementaryGroups = [cfg.containerSocketGroup];
-        ExecStartPre = lib.optionals rootlessSocket [
-          "+${pkgs.acl}/bin/setfacl -m g:${cfg.containerSocketGroup}:--x ${runtimeDir} ${socketDir}"
-        ];
+        DynamicUser = lib.mkForce false;
+        User = "root";
+        Group = "root";
       };
 
       # Second Alloy config file in the same /etc/alloy dir. The upstream module

--- a/tests/alloy-containers/test_alloy_containers.py
+++ b/tests/alloy-containers/test_alloy_containers.py
@@ -11,12 +11,11 @@ def test_container_metrics_cover_rootless_podman_and_docker():
     module = MODULE.read_text()
     discovery = DISCOVERY.read_text()
 
-    assert "containerSocketGroup" in module
-    assert "setfacl" in module
+    assert "DynamicUser = lib.mkForce false" in module
+    assert 'User = "root"' in module
     assert 'target_label = "host"' in module
     assert "m.nixos.alloy-containers" in discovery
     assert 'containerSocket = "unix:///run/docker.sock"' in discovery
-    assert 'containerSocketGroup = "docker"' in discovery
 
 
 def test_container_name_labels_have_a_live_verification_recipe():
@@ -24,5 +23,6 @@ def test_container_name_labels_have_a_live_verification_recipe():
 
     assert "verify-container-metrics:" in recipe
     assert 'container_last_seen{name!=""}' in recipe
+    assert "jq --arg host \"$host\"" in recipe
     for host in ("discovery", "kepler", "orion"):
         assert host in recipe


### PR DESCRIPTION
## Summary
- run cAdvisor-enabled Alloy as root so it can inspect runtime storage metadata
- fix the live Prometheus verifier jq argument
- add a documented collector diagnostic recipe

## Verification
- pytest -q tests/alloy-containers/test_alloy_containers.py
- just lint
- just fmt-check
- just dry discovery
- just dry kepler
- just dry orion
- live logs confirmed DynamicUser permission failures before this fix