### PR TITLE
fix(monitoring): point cAdvisor at Docker containerd

### DIFF
--- a/modules/hosts/discovery/default.nix
+++ b/modules/hosts/discovery/default.nix
@@ -62,6 +62,7 @@ in {
 
     homelab.alloy = {
       containerSocket = "unix:///run/docker.sock";
+      containerdSocket = "/run/docker/containerd/containerd.sock";
     };
 
     # NetBird IdP bring-up (RFC docs/proposals/2026-07-11-pocketid-idp-for-netbird.md

--- a/modules/services/alloy-containers.nix
+++ b/modules/services/alloy-containers.nix
@@ -18,6 +18,12 @@ _: {
       '';
     };
 
+    options.homelab.alloy.containerdSocket = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Containerd endpoint used by Docker's overlayfs storage driver.";
+    };
+
     config = lib.mkIf (cfg.containerSocket != null) {
       # cAdvisor inspects runtime sockets, cgroups, and container storage metadata.
       # A DynamicUser can reach the socket but cannot read rootless Podman storage.
@@ -39,6 +45,7 @@ _: {
         // modules/services/alloy-containers.nix). Replaces a cAdvisor sidecar.
         prometheus.exporter.cadvisor "containers" {
           docker_host            = "${cfg.containerSocket}"
+          ${lib.optionalString (cfg.containerdSocket != null) ''containerd_host        = "${cfg.containerdSocket}"''}
           store_container_labels = true
         }
 

--- a/tests/alloy-containers/test_alloy_containers.py
+++ b/tests/alloy-containers/test_alloy_containers.py
@@ -13,9 +13,11 @@ def test_container_metrics_cover_rootless_podman_and_docker():
 
     assert "DynamicUser = lib.mkForce false" in module
     assert 'User = "root"' in module
+    assert "containerd_host" in module
     assert 'target_label = "host"' in module
     assert "m.nixos.alloy-containers" in discovery
     assert 'containerSocket = "unix:///run/docker.sock"' in discovery
+    assert 'containerdSocket = "/run/docker/containerd/containerd.sock"' in discovery
 
 
 def test_container_name_labels_have_a_live_verification_recipe():


### PR DESCRIPTION
## Summary
- configure Discovery cAdvisor with dockerd’s actual containerd endpoint
- leave Podman hosts unchanged

## Verification
- pytest -q tests/alloy-containers/test_alloy_containers.py
- just lint
- just fmt-check
- just dry discovery