### PR TITLE
ci: notify Discord on failures

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,3 +68,17 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@e50d5f73bfe71c2dd0aa4218de8f4afa59f8f81d # v16
       - name: k3s smoke test
         run: nix build .#checks.x86_64-linux.k3s-smoke -L
+
+  notify-ci:
+    needs: [lint, eval, flake-lock, k3s-smoke]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify CI channel
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_CI_WEBHOOK }}
+        run: |
+          if [[ -z "$WEBHOOK" ]]; then echo "::notice::DISCORD_CI_WEBHOOK not configured"; exit 0; fi
+          jq -nc --arg repo "$GITHUB_REPOSITORY" --arg ref "$GITHUB_REF_NAME" --arg actor "$GITHUB_ACTOR" --arg url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            '{allowed_mentions:{parse:[]},embeds:[{title:"CI FAILED",description:("**Repository:** `"+$repo+"`\n**Ref:** `"+$ref+"`\n**Actor:** `"+$actor+"`\n[Open workflow]("+$url+")"),color:15548997}]}' |
+            curl -fsS -H "Content-Type: application/json" --data @- "$WEBHOOK"

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ Thumbs.db
 !.env.example
 # Local handoff for B2/Modal credentials; populate, migrate to sops, then delete.
 /provider-credentials.local.json
+# Local handoff for Discord webhook secrets; populate, distribute, then delete.
+/discord-webhooks.local.json
 # One-off plaintext credential handoff (Homelab Zen key) — never commit; delete after wiring.
 zen.md
 node_modules/


### PR DESCRIPTION
Post a redacted, mention-disabled Discord alert when required CI jobs fail. Logs remain in GitHub Actions.