### PR TITLE
fix(monitoring): scrape Podman exporter metrics

### DIFF
--- a/modules/hosts/kepler/compose.nix
+++ b/modules/hosts/kepler/compose.nix
@@ -12,6 +12,7 @@ _: {
         # (knowledge, photos, cicd, security) remain manual until migrated off
         # the legacy TrueNAS deployment.
         "infra"
+        "monitoring"
         "whisper-gpu"
         "docs-search"
         "qwen4b-gpu"

--- a/modules/hosts/kepler/default.nix
+++ b/modules/hosts/kepler/default.nix
@@ -35,10 +35,8 @@ in {
       m.nixos.fleet-dns
     ];
 
-    # Per-container metrics via the cAdvisor exporter in the host Alloy. Rootless
-    # Podman socket (matches kepler-compose's dockerSocket). Feeds the fleet
-    # container-down / crash-loop alerts on discovery.
-    homelab.alloy.containerSocket = "unix:///run/user/1000/podman/podman.sock";
+    # Per-container metrics from the loopback prometheus-podman-exporter stack.
+    homelab.alloy.podmanExporter = true;
 
     # Off-site target for discovery's tofu-state restic backup (dedicated,
     # sftp-only user; repo on the bulk pool). Pairs with discovery's

--- a/modules/hosts/orion/compose.nix
+++ b/modules/hosts/orion/compose.nix
@@ -4,6 +4,7 @@ _: {
       composeDir = "/home/erik/servarr/machines/orion";
       stacks = [
         "shared" # scrutiny-collector
+        "monitoring" # prometheus-podman-exporter
         "ai-models" # llama-server (AMD Vulkan GPU)
         # hermes-agent relocated to Discovery 2026-05-23 (always-on host)
       ];

--- a/modules/hosts/orion/default.nix
+++ b/modules/hosts/orion/default.nix
@@ -64,10 +64,8 @@ in {
     # throughput once training runs are done.
     orionGpu.profile = "training";
 
-    # Per-container metrics via the cAdvisor exporter in the host Alloy. Rootless
-    # Podman socket (orchestration default, matches orion-compose). Feeds the
-    # fleet container-down / crash-loop alerts on discovery.
-    homelab.alloy.containerSocket = "unix:///run/user/1000/podman/podman.sock";
+    # Per-container metrics from the loopback prometheus-podman-exporter stack.
+    homelab.alloy.podmanExporter = true;
 
     # Rollback guard: orion is the fleet binary cache + build offload target.
     modules.upgradeHealthCheck.extraCriticalUnits = [

--- a/modules/services/alloy-containers.nix
+++ b/modules/services/alloy-containers.nix
@@ -24,45 +24,57 @@ _: {
       description = "Containerd endpoint used by Docker's overlayfs storage driver.";
     };
 
-    config = lib.mkIf (cfg.containerSocket != null) {
-      # cAdvisor inspects runtime sockets, cgroups, and container storage metadata.
-      # A DynamicUser can reach the socket but cannot read rootless Podman storage.
-      systemd.services.alloy.serviceConfig = {
-        DynamicUser = lib.mkForce false;
-        User = "root";
-        Group = "root";
-      };
-
-      # Second Alloy config file in the same /etc/alloy dir. The upstream module
-      # loads every *.alloy file in configPath (default /etc/alloy) and merges
-      # them into one config graph, so this references the base config's
-      # prometheus.remote_write.prometheus receiver directly. It also lands in
-      # the service's reloadTriggers, so a switch reloads (no restart) on change.
-      # Component names (cadvisor "containers", scrape "container_metrics") must
-      # not collide with the base config — they don't.
-      environment.etc."alloy/containers.alloy".text = ''
-        // Container metrics via cAdvisor exporter (host add-on; see
-        // modules/services/alloy-containers.nix). Replaces a cAdvisor sidecar.
-        prometheus.exporter.cadvisor "containers" {
-          docker_host            = "${cfg.containerSocket}"
-          ${lib.optionalString (cfg.containerdSocket != null) ''containerd_host        = "${cfg.containerdSocket}"''}
-          store_container_labels = true
-        }
-
-        prometheus.scrape "container_metrics" {
-          targets         = prometheus.exporter.cadvisor.containers.targets
-          forward_to      = [prometheus.relabel.container_host.receiver]
-          scrape_interval = "30s"
-        }
-
-        prometheus.relabel "container_host" {
-          rule {
-            target_label = "host"
-            replacement  = "${config.networking.hostName}"
-          }
-          forward_to = [prometheus.remote_write.prometheus.receiver]
-        }
-      '';
+    options.homelab.alloy.podmanExporter = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Scrape prometheus-podman-exporter on loopback.";
     };
+
+    config = lib.mkMerge [
+      (lib.mkIf (cfg.containerSocket != null) {
+        # cAdvisor inspects runtime sockets, cgroups, and container storage metadata.
+        systemd.services.alloy.serviceConfig = {
+          DynamicUser = lib.mkForce false;
+          User = "root";
+          Group = "root";
+        };
+
+        environment.etc."alloy/containers.alloy".text = ''
+          prometheus.exporter.cadvisor "containers" {
+            docker_host            = "${cfg.containerSocket}"
+            ${lib.optionalString (cfg.containerdSocket != null) ''containerd_host        = "${cfg.containerdSocket}"''}
+            store_container_labels = true
+          }
+
+          prometheus.scrape "container_metrics" {
+            targets         = prometheus.exporter.cadvisor.containers.targets
+            forward_to      = [prometheus.relabel.container_host.receiver]
+            scrape_interval = "30s"
+          }
+
+          prometheus.relabel "container_host" {
+            rule {
+              target_label = "host"
+              replacement  = "${config.networking.hostName}"
+            }
+            forward_to = [prometheus.remote_write.prometheus.receiver]
+          }
+        '';
+      })
+
+      (lib.mkIf cfg.podmanExporter {
+        environment.etc."alloy/podman.alloy".text = ''
+          prometheus.scrape "podman" {
+            targets = [{
+              "__address__" = "127.0.0.1:9882",
+              "job"         = "podman",
+              "host"        = "${config.networking.hostName}",
+            }]
+            forward_to      = [prometheus.remote_write.prometheus.receiver]
+            scrape_interval = "30s"
+          }
+        '';
+      })
+    ];
   };
 }

--- a/tests/alloy-containers/test_alloy_containers.py
+++ b/tests/alloy-containers/test_alloy_containers.py
@@ -4,6 +4,10 @@ from pathlib import Path
 ROOT = Path(__file__).parents[2]
 MODULE = ROOT / "modules/services/alloy-containers.nix"
 DISCOVERY = ROOT / "modules/hosts/discovery/default.nix"
+KEPLER = ROOT / "modules/hosts/kepler/default.nix"
+KEPLER_COMPOSE = ROOT / "modules/hosts/kepler/compose.nix"
+ORION = ROOT / "modules/hosts/orion/default.nix"
+ORION_COMPOSE = ROOT / "modules/hosts/orion/compose.nix"
 JUSTFILE = ROOT / "justfile"
 
 
@@ -28,3 +32,21 @@ def test_container_name_labels_have_a_live_verification_recipe():
     assert "jq --arg host \"$host\"" in recipe
     for host in ("discovery", "kepler", "orion"):
         assert host in recipe
+
+
+def test_podman_hosts_scrape_the_dedicated_exporter_without_privileged_cadvisor():
+    module = MODULE.read_text()
+
+    assert "podmanExporter" in module
+    assert '"127.0.0.1:9882"' in module
+    assert '"job"         = "podman"' in module
+
+    for host_file, compose_file in (
+        (KEPLER, KEPLER_COMPOSE),
+        (ORION, ORION_COMPOSE),
+    ):
+        host = host_file.read_text()
+        compose = compose_file.read_text()
+        assert "podmanExporter = true" in host
+        assert "containerSocket" not in host
+        assert '"monitoring"' in compose


### PR DESCRIPTION
Switches Kepler and Orion from privileged embedded cAdvisor to the dedicated loopback prometheus-podman-exporter stack. Adds the monitoring stack to boot ordering and forwards exporter metrics with host labels. Discovery keeps native Docker cAdvisor.\n\nVerified: 3 contract tests, lint, fmt-check, dry builds for Kepler and Orion.