### PR TITLE
fix(desktop): reuse Nautilus window

### DIFF
--- a/docs/guides/yazi.md
+++ b/docs/guides/yazi.md
@@ -16,7 +16,7 @@ without relearning anything.
 
 | Shortcut | Opens |
 |----------|-------|
-| `SUPER + E` | **Nautilus** — a fresh GUI window |
+| `SUPER + E` | **Nautilus** — opens or focuses the existing window |
 | double-click a folder | yazi (via mime handler) |
 | `SUPER + SHIFT + E` | **yazi** (in ghostty), resuming its last folder |
 | `SUPER + /` | **Cheatsheet popup** (rofi) — the same table as below |

--- a/modules/desktop/hyprland.nix
+++ b/modules/desktop/hyprland.nix
@@ -84,7 +84,7 @@
 
         settings = {
           terminal = {_var = "ghostty +new-window";};
-          fileManager = {_var = "nautilus --new-window";};
+          fileManager = {_var = "nautilus";};
           fileManagerTui = {_var = "ghostty +new-window -e yazi-resume";};
           browser = {_var = "brave";};
           teamsApp = {_var = "brave --user-data-dir=$HOME/.local/share/brave-webapps/teams --no-first-run --no-default-browser-check --app=https://teams.microsoft.com/v2/";};

--- a/tests/desktop-file-managers/test_file_managers.py
+++ b/tests/desktop-file-managers/test_file_managers.py
@@ -13,7 +13,7 @@ def test_desktop_shortcuts_and_environment():
     hyprland = HYPRLAND.read_text()
 
     assert '"XDG_DATA_DIRS"' not in hyprland
-    assert 'fileManager = {_var = "nautilus --new-window";};' in hyprland
+    assert 'fileManager = {_var = "nautilus";};' in hyprland
     assert (
         'fileManagerTui = {_var = "ghostty +new-window -e yazi-resume";};'
         in hyprland


### PR DESCRIPTION
Remove `--new-window` from the Hyprland launcher so Super+E focuses an existing Nautilus window instead of forcing another cold window. Updates the behavior test and Yazi guide.