### PR TITLE
fix(monitoring): verify native container exporters

### DIFF
--- a/justfile
+++ b/justfile
@@ -3177,12 +3177,13 @@ verify-k3s-observability:
     printf '%s\n' "$response" | jq -c '.data.result[]? | {instance: .metric.instance, value: .value[1]}'
     test "$(printf '%s\n' "$response" | jq '[.data.result[]? | select(.value[1] == "1")] | length')" -eq 3
 
-# Prove every compose host exports cAdvisor series with container names.
+# Prove every compose host exports container identity through its native
+# collector: cAdvisor on Docker, podman-exporter on rootless Podman.
 verify-container-metrics:
     #!/usr/bin/env bash
     set -euo pipefail
     response=$(curl --fail --silent --show-error --get http://discovery:9090/api/v1/query \
-      --data-urlencode 'query=container_last_seen{name!=""}')
+      --data-urlencode 'query=container_last_seen{name!=""} or podman_container_info{name!=""}')
     for host in discovery kepler orion; do
       count=$(printf '%s\n' "$response" | jq --arg host "$host" '[.data.result[]? | select(.metric.host == $host)] | length')
       printf '%s named_containers=%s\n' "$host" "$count"

--- a/tests/alloy-containers/test_alloy_containers.py
+++ b/tests/alloy-containers/test_alloy_containers.py
@@ -28,7 +28,7 @@ def test_container_name_labels_have_a_live_verification_recipe():
     recipe = JUSTFILE.read_text()
 
     assert "verify-container-metrics:" in recipe
-    assert 'container_last_seen{name!=""}' in recipe
+    assert 'container_last_seen{name!=""} or podman_container_info{name!=""}' in recipe
     assert "jq --arg host \"$host\"" in recipe
     for host in ("discovery", "kepler", "orion"):
         assert host in recipe


### PR DESCRIPTION
## Summary
- verify Docker identity through cAdvisor metrics
- verify rootless Podman identity through podman-exporter metrics
- keep one fleet count loop across both collectors

## Verification
- `pytest -q tests/alloy-containers/test_alloy_containers.py`
- `just verify-container-metrics` (71/11/5)
- `just lint`
- `just fmt-check`