### PR TITLE
fix(observability): add peer dead-man probe

### DIFF
--- a/modules/hosts/kepler/default.nix
+++ b/modules/hosts/kepler/default.nix
@@ -30,6 +30,7 @@ in {
       m.nixos.first-boot
       m.nixos.alloy
       m.nixos.alloy-containers
+      m.nixos.dead-mans-switch
       m.nixos.power-desktop
       m.nixos.restic-offsite-target
       m.nixos.fleet-dns
@@ -37,6 +38,15 @@ in {
 
     # Per-container metrics from the loopback prometheus-podman-exporter stack.
     homelab.alloy.podmanExporter = true;
+
+    # Discovery hosts Grafana and the primary alert path. Probe a public
+    # Discovery endpoint from Kepler and post through the independent
+    # SOPS-managed webhook after 15 minutes of silence.
+    services.deadMansSwitch = {
+      enable = true;
+      checkUrl = "https://id.${config.flake.fleet.ingress.homelab.zone}";
+      failureThreshold = 3;
+    };
 
     # Off-site target for discovery's tofu-state restic backup (dedicated,
     # sftp-only user; repo on the bulk pool). Pairs with discovery's

--- a/modules/services/alloy.nix
+++ b/modules/services/alloy.nix
@@ -18,8 +18,10 @@ _: {
     # success (e.g. `<job>_last_success_seconds <epoch>`), the unix exporter
     # surfaces it, and Grafana alerts on staleness — a declarative dead-man's
     # switch in the metrics pipeline (replaces self-hosted Healthchecks for
-    # host-systemd jobs). 0755 so the alloy user can read what root-run jobs write.
-    systemd.tmpfiles.rules = ["d /var/lib/node-exporter-textfile 0755 root root - -"];
+    # host-systemd jobs). Rootless compose runs as the fleet user; ownership
+    # lets rootless compose (fleet user `erik`) atomically publish gauges while
+    # Alloy retains read access.
+    systemd.tmpfiles.rules = ["d /var/lib/node-exporter-textfile 0755 erik users - -"];
 
     environment.etc."alloy/config.alloy".text = ''
       // Grafana Alloy configuration — fleet-wide NixOS module

--- a/modules/services/dead-mans-switch.nix
+++ b/modules/services/dead-mans-switch.nix
@@ -42,7 +42,7 @@ in {
       if [ "$failures" -eq ${toString cfg.failureThreshold} ]; then
         webhook=$(cat "${webhookPath}")
         ${pkgs.curl}/bin/curl --silent --max-time 10 -X POST -H 'Content-Type: application/json' \
-          --data "{\"content\": \"vanguard dead-man's-switch: ${cfg.checkUrl} unreachable for $failures consecutive checks — the home fleet may be dark.\"}" \
+          --data "{\"content\": \"${config.networking.hostName} dead-man's-switch: ${cfg.checkUrl} unreachable for $failures consecutive checks — Discovery or home ingress may be down.\"}" \
           "$webhook" || true
       fi
     '';

--- a/tests/alloy/test_alloy.py
+++ b/tests/alloy/test_alloy.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE = ROOT / "modules/services/alloy.nix"
+
+
+def test_textfile_directory_is_writable_by_rootless_compose_owner():
+    text = MODULE.read_text()
+    assert "d /var/lib/node-exporter-textfile 0755 erik users - -" in text

--- a/tests/dead-mans-switch/test_kepler_dead_mans_switch.py
+++ b/tests/dead-mans-switch/test_kepler_dead_mans_switch.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_kepler_runs_the_discovery_dead_mans_switch():
+    kepler = (ROOT / "modules/hosts/kepler/default.nix").read_text()
+    assert "m.nixos.dead-mans-switch" in kepler
+    assert "services.deadMansSwitch = {" in kepler
+    assert "enable = true;" in kepler
+    assert 'checkUrl = "https://id.' in kepler
+
+
+def test_notification_identifies_the_actual_observer():
+    module = (ROOT / "modules/services/dead-mans-switch.nix").read_text()
+    assert "${config.networking.hostName} dead-man's-switch" in module


### PR DESCRIPTION
## Summary
- let rootless compose backup jobs publish Alloy textfile gauges
- enable the independent dead-man probe on Kepler
- identify the reporting host in Discord notifications

## Verification
- `just lint`
- `just fmt-check`
- `just dry kepler`
- `just dry discovery`
- `just dry orion`
- `just dry pathfinder`
- `just dry endeavour`
- 3 focused tests