### PR TITLE
fix(kepler): activate backup stack

### DIFF
--- a/modules/hosts/kepler/compose.nix
+++ b/modules/hosts/kepler/compose.nix
@@ -13,8 +13,8 @@ _: {
         # the legacy TrueNAS deployment.
         "infra"
         "monitoring"
+        "sync"
         "whisper-gpu"
-        "docs-search"
         "qwen4b-gpu"
       ];
     };

--- a/tests/kepler-compose/test_kepler_compose.py
+++ b/tests/kepler-compose/test_kepler_compose.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE = ROOT / "modules/hosts/kepler/compose.nix"
+
+
+def test_enabled_stacks_include_backup_and_exclude_empty_profile():
+    text = MODULE.read_text()
+    assert '"sync"' in text
+    assert '"docs-search"' not in text


### PR DESCRIPTION
## Summary
- enable the authored sync/restic stack on Kepler
- remove the empty docs-search compose profile that crash-looped its systemd unit

## Verification
- focused contract passes
- `just lint`
- `just fmt-check`
- `just dry kepler`