### PR TITLE
fix(kindle): allow unrelated compose edits

### DIFF
--- a/modules/hosts/discovery/_kindle-release-agent.py
+++ b/modules/hosts/discovery/_kindle-release-agent.py
@@ -856,10 +856,10 @@ def verify_active_commit(runner, commit):
     if not COMMIT_RE.fullmatch(commit):
         raise ValueError("invalid active commit")
     git = ["runuser", "-u", "erik", "--", "git", "-C", str(SERVARR_REPO)]
-    expected = runner.run(git + ["rev-parse", f"{commit}:{COMPOSE_PATH}"]).strip()
-    actual = runner.run(git + ["hash-object", str(SERVARR_REPO / COMPOSE_PATH)]).strip()
+    expected = parse_pin(runner.run(git + ["show", f"{commit}:{COMPOSE_PATH}"]))
+    actual = parse_pin(runner.run(["cat", str(SERVARR_REPO / COMPOSE_PATH)]))
     if actual != expected:
-        raise ValueError("active Kindle compose mismatch for recorded commit")
+        raise ValueError("active Kindle image mismatch for recorded commit")
 
 
 def recreate_kindle(runner, uid):

--- a/tests/kindle-release-agent/test_agent.py
+++ b/tests/kindle-release-agent/test_agent.py
@@ -98,21 +98,27 @@ class PinContract(unittest.TestCase):
                 f"    image: {self.pin}\n",
             )
 
-    def test_active_revision_allows_unrelated_repository_advances(self):
+    def test_active_revision_allows_unrelated_compose_changes(self):
         runner = mock.Mock()
-        runner.run.side_effect = ["expected-blob\n", "expected-blob\n"]
+        expected = f"services:\n  kindle:\n    image: {self.pin}\n"
+        actual = f"services:\n  kindle:\n    image: {self.pin}\n    logging:\n      driver: journald\n"
+        runner.run.side_effect = [expected, actual]
         commit = "b" * 40
         self.agent.verify_active_commit(runner, commit)
         commands = runner.run.call_args_list
         self.assertEqual(len(commands), 2)
         self.assertIn(f"{commit}:{self.agent.COMPOSE_PATH}", commands[0].args[0])
-        self.assertIn("hash-object", commands[1].args[0])
+        self.assertIn("show", commands[0].args[0])
+        self.assertIn("cat", commands[1].args[0])
         self.assertNotIn("HEAD", commands[0].args[0] + commands[1].args[0])
 
-    def test_active_revision_rejects_compose_drift(self):
+    def test_active_revision_rejects_image_drift(self):
         runner = mock.Mock()
-        runner.run.side_effect = ["expected-blob\n", "different-blob\n"]
-        with self.assertRaisesRegex(ValueError, "active Kindle compose mismatch"):
+        runner.run.side_effect = [
+            f"image: {self.pin}\n",
+            f"image: {self.agent.HARBOR_IMAGE}:v9.9.9@sha256:{'b' * 64}\n",
+        ]
+        with self.assertRaisesRegex(ValueError, "active Kindle image mismatch"):
             self.agent.verify_active_commit(runner, "b" * 40)
 
 
@@ -1689,8 +1695,8 @@ class BootstrapContract(unittest.TestCase):
             "",
             self.digest + "\n",
             self.digest + "\n",
-            "compose-blob\n",
-            "compose-blob\n",
+            self.compose,
+            self.compose,
             json.dumps([self.container]),
             json.dumps([self.image]),
         ]


### PR DESCRIPTION
## Summary
- verify the recorded Kindle image pin instead of the complete compose blob
- preserve rejection of image tag or digest drift
- allow unrelated operational compose changes such as logging drivers

## Test
- `just test-kindle-release-agent` (97 tests)
- `just lint`
- `just fmt-check`
- targeted Discovery toplevel `--dry-run`