### PR TITLE
fix(kindle): skip non-release compose edits

### DIFF
--- a/modules/hosts/discovery/_kindle-release-agent.py
+++ b/modules/hosts/discovery/_kindle-release-agent.py
@@ -714,12 +714,18 @@ def observe_candidate(runner, previous_commit):
     ).splitlines()
     if not candidates:
         return None
-    candidate = candidates[0]
-    changed_paths = runner.run(
-        git + ["diff-tree", "--no-commit-id", "--name-only", "-r", candidate]
-    ).splitlines()
-    compose_text = runner.run(git + ["show", f"{candidate}:{COMPOSE_PATH}"])
-    return validate_candidate(candidate, changed_paths, compose_text)
+    previous_pin = parse_pin(
+        runner.run(git + ["show", f"{previous_commit}:{COMPOSE_PATH}"])
+    )
+    for candidate in candidates:
+        compose_text = runner.run(git + ["show", f"{candidate}:{COMPOSE_PATH}"])
+        if parse_pin(compose_text) == previous_pin:
+            continue
+        changed_paths = runner.run(
+            git + ["diff-tree", "--no-commit-id", "--name-only", "-r", candidate]
+        ).splitlines()
+        return validate_candidate(candidate, changed_paths, compose_text)
+    return None
 
 
 def observe_live_release(runner):

--- a/tests/kindle-release-agent/test_agent.py
+++ b/tests/kindle-release-agent/test_agent.py
@@ -1068,8 +1068,9 @@ class ObservationContract(unittest.TestCase):
                 self.target + "\n",
                 "",
                 self.target + "\n",
-                self.agent.COMPOSE_PATH + "\n",
+                self.compose.replace("v1.2.3", "v1.2.2"),
                 self.compose,
+                self.agent.COMPOSE_PATH + "\n",
             ]
         )
         candidate = self.agent.observe_candidate(runner, self.previous)
@@ -1110,16 +1111,21 @@ class ObservationContract(unittest.TestCase):
                 ],
                 [
                     *git,
-                    "diff-tree",
-                    "--no-commit-id",
-                    "--name-only",
-                    "-r",
-                    self.target,
+                    "show",
+                    f"{self.previous}:{self.agent.COMPOSE_PATH}",
                 ],
                 [
                     *git,
                     "show",
                     f"{self.target}:{self.agent.COMPOSE_PATH}",
+                ],
+                [
+                    *git,
+                    "diff-tree",
+                    "--no-commit-id",
+                    "--name-only",
+                    "-r",
+                    self.target,
                 ],
             ],
         )
@@ -1132,8 +1138,9 @@ class ObservationContract(unittest.TestCase):
                 self.target,
                 "",
                 self.target,
-                self.agent.COMPOSE_PATH + "\nother.yml\n",
+                self.compose.replace("v1.2.3", "v1.2.2"),
                 self.compose,
+                self.agent.COMPOSE_PATH + "\nother.yml\n",
             ]
         )
         with self.assertRaises(ValueError):
@@ -1141,6 +1148,13 @@ class ObservationContract(unittest.TestCase):
 
     def test_observation_ignores_advances_without_compose_change(self):
         runner = self.Runner(["", self.target, "", ""])
+        self.assertIsNone(self.agent.observe_candidate(runner, self.previous))
+
+    def test_observation_ignores_non_release_compose_change(self):
+        runner = self.Runner(
+            ["", self.target, "", self.target, self.compose, self.compose]
+        )
+
         self.assertIsNone(self.agent.observe_candidate(runner, self.previous))
 
     def test_observation_returns_none_when_main_has_not_advanced(self):


### PR DESCRIPTION
## Summary
- skip compose revisions whose Kindle image pin is unchanged
- retain fixed-path isolation for actual image releases
- add regression coverage for logging-style edits

## Test
- `just test-kindle-release-agent` (98 tests)
- `just lint`
- `just fmt-check`
- targeted Discovery toplevel `--dry-run`