### PR TITLE
fix(kepler): allow Postgres metrics scrape

### DIFF
--- a/modules/hosts/kepler/networking.nix
+++ b/modules/hosts/kepler/networking.nix
@@ -34,6 +34,8 @@ _: {
       };
     };
 
+    networking.firewall.interfaces.tailscale0.allowedTCPPorts = [9187];
+
     # Tailscale client — no subnet routing needed (not the gateway host)
     services.tailscale = {
       useRoutingFeatures = lib.mkForce "client";

--- a/tests/postgres-exporter-firewall/test_contract.py
+++ b/tests/postgres-exporter-firewall/test_contract.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+MODULE = (
+    Path(__file__).parents[2] / "modules" / "hosts" / "kepler" / "networking.nix"
+).read_text()
+
+
+def test_postgres_exporter_is_tailnet_only():
+    assert "interfaces.tailscale0.allowedTCPPorts = [9187];" in MODULE
+    global_ports = MODULE.split("allowedTCPPorts = [", 1)[1].split("];", 1)[0]
+    assert "9187" not in global_ports


### PR DESCRIPTION
## Summary
- permit postgres-exporter only on `tailscale0`
- keep port 9187 closed on LAN interfaces
- lock interface scope with a contract test

## Validation
- `pytest -q tests/postgres-exporter-firewall/test_contract.py`
- `just lint`
- `just fmt-check`
- `just dry kepler`