### PR TITLE
fix(kepler): stop duplicate ZFS mounts

### DIFF
--- a/modules/hosts/kepler/hardware.nix
+++ b/modules/hosts/kepler/hardware.nix
@@ -101,6 +101,9 @@ _: {
       fsType = "zfs";
       options = ["zfsutil" "X-mount.mkdir" "nofail"];
     };
+    # These datasets are mounted above; `zfs mount -a` races their generated
+    # mount units and leaves zfs-mount.service failed despite healthy mounts.
+    systemd.services.zfs-mount.enable = false;
 
     # --- RTX 3070 LHR (GA104): headless CUDA, no display ---
     services.xserver.videoDrivers = ["nvidia"];

--- a/tests/kepler-zfs-mount/test_contract.py
+++ b/tests/kepler-zfs-mount/test_contract.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+MODULE = (
+    Path(__file__).parents[2] / "modules" / "hosts" / "kepler" / "hardware.nix"
+).read_text()
+
+
+def test_explicit_mounts_disable_legacy_mount_all():
+    assert 'fileSystems."/fast"' in MODULE
+    assert 'fileSystems."/bulk"' in MODULE
+    assert "systemd.services.zfs-mount.enable = false;" in MODULE


### PR DESCRIPTION
## Summary
- disable legacy `zfs mount -a` on Kepler
- keep `/fast` and `/bulk` owned by explicit Nix mount units
- lock the no-duplicate-mount contract

## Validation
- `pytest -q tests/kepler-zfs-mount/test_contract.py`
- `just lint`
- `just fmt-check`
- `just dry kepler`