### PR TITLE
fix(alloy): label self-metrics by host

### DIFF
--- a/modules/services/alloy.nix
+++ b/modules/services/alloy.nix
@@ -91,6 +91,7 @@ _: {
       prometheus.scrape "alloy_self" {
         targets = [{
           __address__ = "127.0.0.1:12345",
+          instance    = "${config.networking.hostName}",
         }]
         metrics_path    = "/metrics"
         forward_to      = [prometheus.remote_write.prometheus.receiver]

--- a/tests/alloy-self-metrics/test_instance_label.py
+++ b/tests/alloy-self-metrics/test_instance_label.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+ALLOY = Path(__file__).parents[2] / "modules/services/alloy.nix"
+
+
+def test_alloy_self_metrics_use_fleet_hostname_as_instance():
+    module = ALLOY.read_text()
+    block = module.split('prometheus.scrape "alloy_self"', 1)[1].split(
+        'prometheus.scrape "tailscale"', 1
+    )[0]
+
+    assert 'instance    = "${config.networking.hostName}"' in block


### PR DESCRIPTION
## Summary
- label Alloy self-metrics with fleet hostname
- prevent cross-host Prometheus series collisions
- add regression coverage

## Validation
- targeted regression passes
- lint and format checks pass
- dry builds pass for discovery, kepler, orion, endeavour, and laptop