### PR TITLE
fix(kepler): order and grow MicroVM disks

### DIFF
--- a/justfile
+++ b/justfile
@@ -3219,6 +3219,39 @@ verify-k3s-observability:
     printf '%s\n' "$response" | jq -c '.data.result[]? | {instance: .metric.instance, value: .value[1]}'
     test "$(printf '%s\n' "$response" | jq '[.data.result[]? | select(.value[1] == "1")] | length')" -eq 3
 
+# Grow existing k3s root images to the sizes declared in k3s-cluster.nix.
+# Offline + grow-only: shrinking or an unexpected filesystem aborts.
+resize-kepler-k3s-disks:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ssh -p 2222 erik@{{ip_kepler}} 'sudo bash -s' <<'REMOTE'
+      set -euo pipefail
+      declare -A sizes=(
+        [cp-1]=32768 [cp-2]=32768 [cp-3]=32768
+        [w-1]=131072 [w-2]=131072
+      )
+      names=(cp-1 cp-2 cp-3 w-1 w-2)
+      systemctl stop microvms.target "${names[@]/#/microvm@}"
+      trap 'systemctl start microvms.target' EXIT
+      for name in "${names[@]}"; do
+        image="/fast/microvms/$name/root.img"
+        test -f "$image"
+        file -s "$image" | grep -q 'ext4 filesystem'
+        current=$(stat -c %s "$image")
+        wanted=$((sizes[$name] * 1024 * 1024))
+        (( current > wanted )) && {
+          echo "refusing to shrink $name: $current > $wanted" >&2
+          exit 1
+        }
+        (( current == wanted )) && continue
+        truncate -s "$wanted" "$image"
+        e2fsck -f "$image" || [ "$?" -eq 1 ]
+        resize2fs "$image"
+      done
+      trap - EXIT
+      systemctl start microvms.target
+    REMOTE
+
 # Prove every compose host exports container identity through its native
 # collector: cAdvisor on Docker, podman-exporter on rootless Podman.
 verify-container-metrics:

--- a/modules/hosts/kepler/k3s-cluster.nix
+++ b/modules/hosts/kepler/k3s-cluster.nix
@@ -146,7 +146,7 @@ in {
         # (grill §3). 4G/2vcpu gives etcd+apiserver headroom. 3×4G+2×16G on 62G.
         vcpu = 2;
         mem = 4096;
-        disk = 8192;
+        disk = 32768;
       }
       else let
         i = workerIndex name;
@@ -161,7 +161,7 @@ in {
         mac = "02:00:00:00:fb:0${toString i}";
         vcpu = cfg.workerVcpu;
         mem = cfg.workerMem;
-        disk = 20480;
+        disk = 131072;
       };
 
     mkGuest = name: let
@@ -578,12 +578,19 @@ in {
           "microvm@" = {
             unitConfig.RequiresMountsFor = "/fast/microvms";
           };
+          "microvm-set-booted@" = {
+            unitConfig.RequiresMountsFor = "/fast/microvms";
+          };
           "microvm@cp-1" = {
             overrideStrategy = "asDropin";
             after = ["k3s-bootstrap-materialize.service"];
             requires = ["k3s-bootstrap-materialize.service"];
           };
         }
+        // lib.genAttrs' allNames (name:
+          lib.nameValuePair "install-microvm-${name}" {
+            unitConfig.RequiresMountsFor = "/fast/microvms";
+          })
         # Stagger cold boot to cut the simultaneous-boot vsock-notify contention:
         # cp-1 first (clusterInit), then cp-2 → cp-3 serially (clean sequential etcd
         # join), workers after cp-1 (apiserver is up so they join immediately).

--- a/tests/kepler-fast-state/test_fast_state.py
+++ b/tests/kepler-fast-state/test_fast_state.py
@@ -10,7 +10,22 @@ def test_microvms_use_fast_pool_with_mount_ordering():
     module = MODULE.read_text()
 
     assert 'microvm.stateDir = "/fast/microvms";' in module
-    assert 'unitConfig.RequiresMountsFor = "/fast/microvms";' in module
+    assert "disk = 32768;" in module
+    assert "disk = 131072;" in module
+    assert module.count('unitConfig.RequiresMountsFor = "/fast/microvms";') == 3
+    assert '"microvm-set-booted@"' in module
+    assert '"install-microvm-${name}"' in module
+
+
+def test_disk_resize_is_grow_only_and_offline():
+    justfile = JUSTFILE.read_text()
+
+    recipe = justfile.split("resize-kepler-k3s-disks:", 1)[1]
+    assert "systemctl stop microvms.target" in recipe
+    assert "truncate -s" in recipe
+    assert "e2fsck -f" in recipe
+    assert "resize2fs" in recipe
+    assert "current > wanted" in recipe
 
 
 def test_migration_is_copy_verify_switch_finalize():


### PR DESCRIPTION
## Summary
- require `/fast/microvms` before installer and bookkeeping units
- declare 32 GiB control-plane and 128 GiB worker roots
- add a guarded offline grow-only recipe for existing ext4 images
- extend the existing fast-state contract

## Validation
- `pytest -q tests/kepler-fast-state/test_fast_state.py`
- `just lint`
- `just fmt-check`
- `just dry kepler`

## Incident
Disabling duplicate `zfs mount -a` exposed that generated installer units could run before the explicit `/fast` mount and write into the hidden root mountpoint.