### PR TITLE
fix(orion): keep kernel auditing enabled

### DIFF
--- a/modules/hosts/orion/jovian.nix
+++ b/modules/hosts/orion/jovian.nix
@@ -11,6 +11,10 @@
     jovian.steam.desktopSession = "hyprland";
     jovian.hardware.has.amd.gpu = true;
 
+    # Jovian's bundled SteamOS cmdline disables kernel auditing. Keep its
+    # desktop-GPU tuning explicitly so auditd can collect security evidence.
+    jovian.steamos.enableDefaultCmdlineConfig = false;
+
     # --- AMD GPU environment ---
     environment.variables.AMD_VULKAN_ICD = "RADV";
 
@@ -160,7 +164,14 @@
     };
 
     # --- Silent boot ---
+    # ponytail: first six mirror Jovian boot.nix; remove when upstream exposes an audit toggle.
     boot.kernelParams = lib.mkAfter [
+      "log_buf_len=4M"
+      "amd_iommu=off"
+      "amdgpu.lockup_timeout=5000,10000,10000,5000"
+      "ttm.pages_min=2097152"
+      "amdgpu.sched_hw_submission=4"
+      "amdgpu.dcdebugmask=0x20000"
       "quiet"
       "splash"
       "rd.systemd.show_status=false"

--- a/tests/orion-audit/test_kernel_params.py
+++ b/tests/orion-audit/test_kernel_params.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+
+
+def test_orion_keeps_audit_enabled_without_losing_jovian_gpu_params():
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            ".#nixosConfigurations.orion.config.boot.kernelParams",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    params = json.loads(result.stdout)
+
+    assert "audit=1" in params
+    assert "audit=0" not in params
+    assert "amdgpu.lockup_timeout=5000,10000,10000,5000" in params
+    assert "ttm.pages_min=2097152" in params
+    assert "amdgpu.sched_hw_submission=4" in params


### PR DESCRIPTION
## Summary
- disable Jovian bundled cmdline containing `audit=0`
- preserve its desktop GPU tuning explicitly
- assert Orion retains `audit=1` and required performance parameters

## Validation
- regression test passes
- lint and format pass
- Orion dry build passes