### PR TITLE
fix(kepler): preen MicroVM disks offline

### DIFF
--- a/justfile
+++ b/justfile
@@ -3243,9 +3243,10 @@ resize-kepler-k3s-disks:
           echo "refusing to shrink $name: $current > $wanted" >&2
           exit 1
         }
-        (( current == wanted )) && continue
-        truncate -s "$wanted" "$image"
-        e2fsck -f "$image" || [ "$?" -eq 1 ]
+        if (( current < wanted )); then
+          truncate -s "$wanted" "$image"
+        fi
+        e2fsck -fp "$image" || [ "$?" -eq 1 ]
         resize2fs "$image"
       done
       trap - EXIT

--- a/tests/kepler-fast-state/test_fast_state.py
+++ b/tests/kepler-fast-state/test_fast_state.py
@@ -26,9 +26,10 @@ def test_disk_resize_is_grow_only_and_offline():
     assert "e2fsprogs" in hardware
     assert "systemctl stop microvms.target" in recipe
     assert "truncate -s" in recipe
-    assert "e2fsck -f" in recipe
+    assert "e2fsck -fp" in recipe
     assert "resize2fs" in recipe
     assert "current > wanted" in recipe
+    assert "current == wanted" not in recipe
 
 
 def test_migration_is_copy_verify_switch_finalize():


### PR DESCRIPTION
Makes the merged MicroVM grow recipe use noninteractive ext4 preen mode. Safe repairs return 1 and continue; serious filesystem errors still abort.\n\nVerification: pytest, lint, fmt-check.