### PR TITLE
fix(security): ship public SSH journals

### DIFF
--- a/modules/hosts/vanguard/default.nix
+++ b/modules/hosts/vanguard/default.nix
@@ -21,6 +21,7 @@ in {
       m.nixos.vanguard-networking
       m.nixos.containers
       m.nixos.node-exporter
+      m.nixos.vector-logs
       m.nixos.first-boot
       # Role modules (docs/proposals/2026-07-10-vanguard-second-oracle-node.md).
       # ALL opt-in/disabled by default — importing only registers the options,

--- a/modules/hosts/voyager/default.nix
+++ b/modules/hosts/voyager/default.nix
@@ -21,6 +21,7 @@ in {
       m.nixos.containers
       m.nixos.voyager-compose
       m.nixos.node-exporter
+      m.nixos.vector-logs
       m.nixos.first-boot
       # NetBird native relay (WP3, docs/proposals/2026-07-10-
       # netbird-selfhosted-overlay.md §4a/§6b). Registers services.netbirdRelay

--- a/tests/public-host-journal-telemetry/test_vector.py
+++ b/tests/public-host-journal-telemetry/test_vector.py
@@ -1,0 +1,29 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).parents[2]
+
+
+@pytest.mark.parametrize("host", ["voyager", "vanguard"])
+def test_public_host_ships_journal_to_loki(host):
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            f".#nixosConfigurations.{host}.config.services.vector",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    vector = json.loads(result.stdout)
+
+    assert vector["enable"] is True
+    assert vector["settings"]["sinks"]["loki"]["labels"]["host"] == host
+    assert vector["settings"]["sinks"]["loki"]["labels"]["source"] == "journal"


### PR DESCRIPTION
## Summary
- enable lightweight Vector journal shipping on voyager and vanguard
- preserve the shared `{source="journal", host=...}` Loki schema
- add evaluated Nix regression coverage for both public hosts

## Tests
- `pytest -q tests/public-host-journal-telemetry/test_vector.py`
- evaluated both NixOS system derivations
- `git diff --check`

Required before SSH anomaly alerts: both public-SSH hosts were absent from Loki.