### PR TITLE
Stabilize desktop fleet services

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ top-level module, options replace `specialArgs`, no aggregator boilerplate.
 
 | Host | Role | CPU | RAM | GPU | Storage | IP |
 |------|------|-----|-----|-----|---------|-----|
-| **pathfinder** | Desktop | i7-8750H | 32 GB | GTX 1060 Max-Q + UHD 630 (PRIME sync) | SATA · LUKS+btrfs | 192.168.10.125 |
+| **pathfinder** | Desktop | i7-8750H | 32 GB | GTX 1060 Max-Q + UHD 630 (PRIME sync) | SATA · LUKS+btrfs | 192.168.10.215 |
 | **endeavour** | Laptop · primary workstation | Core Ultra 7 155H | 32 GB | Intel Arc | NVMe · LUKS+btrfs · FIDO2 | Tailscale (roaming) |
 | **orion** | HTPC · build server · dev sandbox | Ryzen 9 5950X | 128 GB | Radeon RX 9070 XT | NVMe btrfs · 2×SATA SSD btrfs | 192.168.10.220 |
 | **discovery** | Home server | i5-4670 | 32 GB | Quadro P2000 | 2×SSD btrfs RAID1 · 3.6TB HDD | 192.168.10.210 |

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -4,7 +4,7 @@
 
 | Host       | Type    | Hardware                                     | IP             |
 | ---------- | ------- | -------------------------------------------- | -------------- |
-| pathfinder | Desktop | Intel i7 + Nvidia GTX 1080, LUKS+btrfs       | 192.168.10.125 |
+| pathfinder | Desktop | Intel i7 + Nvidia GTX 1080, LUKS+btrfs       | 192.168.10.215 |
 | discovery  | Server  | Intel + Nvidia Quadro P2000, RAID1 SSD + HDD | 192.168.10.210 |
 | laptop     | Laptop  | Intel i7-1165G7 + Iris Xe, NVMe LUKS+btrfs   | DHCP           |
 | orion      | HTPC    | AMD Ryzen + RX 9070XT, Jovian Steam UI        | 192.168.10.220 |
@@ -55,7 +55,7 @@ Single command, fully automated after LUKS unlock:
 ```bash
 just nixos-anywhere <target> <ip> <luks-pass> <iso-user>
 # Example:
-just nixos-anywhere pathfinder 192.168.10.125 mypassword nixos
+just nixos-anywhere pathfinder 192.168.10.215 mypassword nixos
 ```
 
 **What happens:**
@@ -91,7 +91,7 @@ just bootstrap laptop
 ```bash
 just verify <target> <ip> <ssh-port>
 # Example:
-just verify pathfinder 192.168.10.125 2222
+just verify pathfinder 192.168.10.215 2222
 ```
 
 Checks: failed units, tailscale status, syncthing, home-manager, sops key presence.
@@ -101,7 +101,7 @@ Checks: failed units, tailscale status, syncthing, home-manager, sops key presen
 ```bash
 just deploy <target> <ip> <port>
 # Example:
-just deploy pathfinder 192.168.10.125 2222
+just deploy pathfinder 192.168.10.215 2222
 ```
 
 ### Fleet auto-update

--- a/fleet.json
+++ b/fleet.json
@@ -37,7 +37,7 @@
       "tailscaleIp": "100.72.85.73"
     },
     "pathfinder": {
-      "ip": "192.168.10.125",
+      "ip": "192.168.10.215",
       "mac": "54:bf:64:28:cb:2e",
       "role": "workstation",
       "tailscaleIp": "100.102.248.13"

--- a/modules/dev/herdr-gemini.nix
+++ b/modules/dev/herdr-gemini.nix
@@ -1,0 +1,197 @@
+{inputs, ...}: {
+  flake.modules.home.herdr-gemini = {
+    config,
+    lib,
+    pkgs,
+    ...
+  }: let
+    herdr = inputs.herdr.packages.${pkgs.stdenv.hostPlatform.system}.default;
+    plusVersion = "0.1.20";
+    navigatorVersion = "0.3.3";
+
+    plusSource = pkgs.fetchurl {
+      url = "https://github.com/cloudmanic/herdr-plus/archive/refs/tags/v${plusVersion}.tar.gz";
+      hash = "sha256-2FEi9oG2UvsSPU92EHru7qHvbHjzRn3ZMSwjX6iF/pc=";
+    };
+    plusBinary = pkgs.fetchurl {
+      url = "https://github.com/cloudmanic/herdr-plus/releases/download/v${plusVersion}/herdr-plus_${plusVersion}_linux_amd64.tar.gz";
+      hash = "sha256-ic4zGjDwmgwEofwNoLNzISKDgZqszKl3zl5UrZmuM48=";
+    };
+    plus =
+      pkgs.runCommand "herdr-plus-${plusVersion}" {
+        nativeBuildInputs = [pkgs.gnutar pkgs.gzip];
+      } ''
+        mkdir -p source $out/bin
+        tar -xzf ${plusSource} -C source --strip-components=1
+        cp source/herdr-plugin.toml $out/herdr-plugin.toml
+        tar -xzf ${plusBinary} -C $out/bin herdr-plus
+        chmod +x $out/bin/herdr-plus
+      '';
+
+    navigatorArchive = pkgs.fetchurl {
+      url = "https://github.com/thanhdat77/herdr-navigator/releases/download/v${navigatorVersion}/herdr-navigator-linux-x86_64.tar.gz";
+      hash = "sha256-KdLB8PYXckXLksHLZfzmESxMd/nBNZi9n4CosYCFPgI=";
+    };
+    navigator =
+      pkgs.runCommand "herdr-navigator-${navigatorVersion}" {
+        nativeBuildInputs = [pkgs.gnutar pkgs.gzip];
+      } ''
+        mkdir -p unpack $out/target/release
+        tar -xzf ${navigatorArchive} -C unpack
+        cp unpack/herdr-navigator/herdr-plugin.toml $out/
+        cp unpack/herdr-navigator/herdr-navigator $out/target/release/
+        chmod +x $out/target/release/herdr-navigator
+      '';
+
+    project = {
+      name,
+      workingDir,
+    }: {
+      inherit name;
+      working_dir = workingDir;
+      tabs = [
+        {
+          name = "editor";
+          command = "nvim .";
+        }
+        {
+          name = "agents";
+          panes = [
+            {
+              label = "Codex 1";
+              command = "codex --yolo";
+            }
+            {
+              label = "Codex 2";
+              command = "codex --yolo";
+              split = "right";
+            }
+            {
+              label = "Codex 3";
+              command = "codex --yolo";
+              split = "down";
+            }
+            {
+              label = "Codex 4";
+              command = "codex --yolo";
+              split = "right";
+            }
+          ];
+        }
+        {
+          name = "terminals";
+          panes = [
+            {label = "Terminal 1";}
+            {
+              label = "Terminal 2";
+              split = "right";
+            }
+          ];
+        }
+      ];
+    };
+    toml = pkgs.formats.toml {};
+    defaults = {
+      homelab = "~/Documents/erik/homelab";
+      dataplatform = "~/Documents/nstech/dataplatform";
+    };
+    defaultSessions = ["homelab" "dataplatform"];
+
+    bootstrap = pkgs.writeShellApplication {
+      name = "herdr-bootstrap";
+      runtimeInputs = [herdr pkgs.jq plus];
+      text = ''
+        session=$1
+        project=$2
+        export HERDR_SESSION="$session"
+
+        for _ in {1..40}; do
+          if workspaces=$(herdr workspace list 2>/dev/null); then
+            if ! jq -e --arg label "$project" \
+              'any(.result.workspaces[]?; .label == $label)' <<<"$workspaces" >/dev/null; then
+              herdr-plus open "$project"
+            fi
+            exit
+          fi
+          sleep 0.25
+        done
+        echo "herdr session $session did not become ready" >&2
+        exit 1
+      '';
+    };
+
+    sessionService = name: {
+      Unit = {
+        Description = "Persistent Herdr session ${name}";
+        After = ["network-online.target"];
+        Wants = ["network-online.target"];
+      };
+      Service = {
+        ExecStart = "${herdr}/bin/herdr --session ${name} server";
+        ExecStartPost = "${bootstrap}/bin/herdr-bootstrap ${name} ${name}";
+        Restart = "on-failure";
+        RestartSec = 2;
+      };
+      Install.WantedBy = ["default.target"];
+    };
+
+    repoBootstrap = pkgs.writeShellApplication {
+      name = "herdr-repo-bootstrap";
+      runtimeInputs = [herdr pkgs.jq pkgs.systemd];
+      text = ''
+        session=$1
+        remote_repo=$2
+        remote_repo="''${remote_repo/#\~/$HOME}"
+        systemctl --user enable --now "herdr-session@$session.service"
+        export HERDR_SESSION="$session"
+        for _ in {1..40}; do
+          if workspaces=$(herdr workspace list 2>/dev/null); then
+            if ! jq -e --arg label "$session" \
+              'any(.result.workspaces[]?; .label == $label)' <<<"$workspaces" >/dev/null; then
+              herdr workspace create --cwd "$remote_repo" --label "$session" --focus
+            fi
+            exit
+          fi
+          sleep 0.25
+        done
+        echo "herdr session $session did not become ready" >&2
+        exit 1
+      '';
+    };
+  in {
+    home.packages = [plus navigator repoBootstrap];
+
+    xdg.configFile = {
+      "herdr/plugins/config/cloudmanic.herdr-plus/projects/homelab.toml".source = toml.generate "herdr-plus-homelab.toml" (project {
+        name = "homelab";
+        workingDir = defaults.homelab;
+      });
+      "herdr/plugins/config/cloudmanic.herdr-plus/projects/dataplatform.toml".source = toml.generate "herdr-plus-dataplatform.toml" (project {
+        name = "dataplatform";
+        workingDir = defaults.dataplatform;
+      });
+    };
+
+    home.activation.linkHerdrPlugins = lib.hm.dag.entryAfter ["installPackages"] ''
+      $DRY_RUN_CMD ${herdr}/bin/herdr plugin link ${plus}
+      $DRY_RUN_CMD ${herdr}/bin/herdr plugin link ${navigator}
+    '';
+
+    systemd.user.services =
+      builtins.listToAttrs (map (name: lib.nameValuePair "herdr-session-${name}" (sessionService name)) defaultSessions)
+      // {
+        "herdr-session@" = {
+          Unit = {
+            Description = "Persistent Herdr repository session %i";
+            After = ["network-online.target"];
+            Wants = ["network-online.target"];
+          };
+          Service = {
+            ExecStart = "${herdr}/bin/herdr --session %i server";
+            Restart = "on-failure";
+            RestartSec = 2;
+          };
+        };
+      };
+  };
+}

--- a/modules/dev/herdr.nix
+++ b/modules/dev/herdr.nix
@@ -15,8 +15,26 @@
   flake.modules.home.herdr = {pkgs, ...}: let
     system = pkgs.stdenv.hostPlatform.system;
     tomlFormat = pkgs.formats.toml {};
+    herdr = inputs.herdr.packages.${system}.default;
+    repoLauncher = pkgs.writeShellApplication {
+      name = "herdr-repo";
+      runtimeInputs = [pkgs.git pkgs.openssh herdr];
+      text = ''
+        repo=$(git -C "''${1:-.}" rev-parse --show-toplevel)
+        session=''${repo##*/}
+        [[ $session =~ ^[A-Za-z0-9_.-]+$ ]] || {
+          echo "unsupported session name: $session" >&2
+          exit 2
+        }
+        remote_repo="''${repo/#$HOME/~}"
+        printf -v remote_command "herdr-repo-bootstrap %q %q" "$session" "$remote_repo"
+        # shellcheck disable=SC2029 # arguments are intentionally quoted client-side
+        ssh gemini "$remote_command"
+        exec herdr --remote gemini --session "$session"
+      '';
+    };
   in {
-    home.packages = [inputs.herdr.packages.${system}.default];
+    home.packages = [herdr repoLauncher];
 
     # Declarative, read-only config. herdr re-reads it on
     # `herdr server reload-config`; onboarding is disabled so it never tries
@@ -84,6 +102,18 @@
           type = "pane";
           command = "hermes";
           description = "launch Hermes Agent (local CLI → Discovery API)";
+        }
+        {
+          key = "prefix+t";
+          type = "plugin_action";
+          command = "herdr-navigator.open";
+          description = "jump to workspace, project, session, or agent";
+        }
+        {
+          key = "prefix+shift+p";
+          type = "plugin_action";
+          command = "cloudmanic.herdr-plus.projects";
+          description = "open project template";
         }
       ];
     };

--- a/modules/hosts/discovery/compose.nix
+++ b/modules/hosts/discovery/compose.nix
@@ -1,5 +1,12 @@
-_: {
-  flake.modules.nixos.discovery-compose = _: {
+{config, ...}: {
+  flake.modules.nixos.discovery-compose = {
+    lib,
+    pkgs,
+    ...
+  }: {
+    home-manager.users.${config.username}.systemd.user.services."podman-compose-monitoring".Service.ExecStartPre =
+      lib.mkBefore ["${pkgs.util-linux}/bin/mountpoint --quiet /home/erik/vault"];
+
     homelab.compose = {
       composeDir = "/home/erik/servarr/machines/discovery";
       # Rootful Docker — socket owned by root, accessible via docker group.
@@ -38,7 +45,7 @@ _: {
       secretSpecRuntimeProfiles.monitoring = "monitoring";
       secretSpecRuntimeSourceConfigNames.monitoring = ["GRAFANA_ADMIN_USER"];
       secretSpecRuntimeIgnoredSourceNames.monitoring = ["CLICKHOUSE_PASSWORD" "LANGFUSE_INIT_USER_PASSWORD" "LANGFUSE_PUBLIC_KEY" "LANGFUSE_SALT" "LANGFUSE_SECRET_KEY" "LITELLM_SALT_KEY" "MINIO_ROOT_PASSWORD" "OPENCODE_GO_KEY" "OPENCODE_ZEN_KEY" "UI_PASSWORD"];
-      secretSpecRuntimeHealthContainers.monitoring = ["grafana" "healthchecks" "scrutiny-influxdb" "scrutiny"];
+      secretSpecRuntimeHealthContainers.monitoring = ["prometheus" "grafana" "loki" "healthchecks" "scrutiny-influxdb" "scrutiny"];
       secretSpecRuntimeProfiles.media = "media";
       secretSpecRuntimeSourceConfigNames.media = ["NORDVPN_USER" "QBITTORRENT_USER"];
       secretSpecRuntimeHealthContainers.media = ["gluetun" "unpackerr" "decluttarr"];

--- a/modules/hosts/kepler/default.nix
+++ b/modules/hosts/kepler/default.nix
@@ -60,6 +60,7 @@ in {
     services.fleetDns = {
       enable = true;
       interface = "enp5s0";
+      listenAddress = config.flake.fleet.hosts.kepler.ip;
       queryLog = false;
       upstream = ["192.168.10.210" "1.1.1.1" "9.9.9.9"];
       sequentialUpstream = true;

--- a/modules/hosts/orion/gemini.nix
+++ b/modules/hosts/orion/gemini.nix
@@ -150,6 +150,7 @@ in {
           isNormalUser = true;
           uid = 1000; # match orion's erik so the forwarded nix-daemon trusts it
           extraGroups = ["wheel"];
+          linger = true; # keep persistent Herdr sessions alive without SSH login
           shell = pkgs.zsh;
           openssh.authorizedKeys.keys = [laptopKey nixBuilderKey];
         };
@@ -196,6 +197,7 @@ in {
               m.home.nvim
               m.home.hermes-agent
               m.home.herdr
+              m.home.herdr-gemini
               m.home.grafatui
               m.home.tmux
             ];
@@ -213,7 +215,6 @@ in {
             programs.home-manager.enable = true;
           };
         };
-
         # Own the synced folder roots as erik BEFORE syncthing starts. The
         # string-path fleet folders (Documents/Downloads) aren't auto-created by
         # the syncthing module (only ensureDir attrset folders are), so without

--- a/modules/meta.nix
+++ b/modules/meta.nix
@@ -85,7 +85,7 @@
           tailscaleIp = "100.94.239.46";
         };
         pathfinder = {
-          ip = "192.168.10.125";
+          ip = "192.168.10.215";
           mac = "54:bf:64:28:cb:2e";
           role = "workstation";
           tailscaleIp = "100.102.248.13";

--- a/modules/services/alloy.nix
+++ b/modules/services/alloy.nix
@@ -1,4 +1,6 @@
-_: {
+{config, ...}: let
+  discoveryTs = config.fleet.hosts.discovery.tailscaleIp;
+in {
   flake.modules.nixos.alloy = {config, ...}: {
     services.alloy = {
       enable = true;
@@ -43,7 +45,7 @@ _: {
 
       loki.write "loki" {
         endpoint {
-          url = "http://discovery:3100/loki/api/v1/push"
+          url = "http://${discoveryTs}:3100/loki/api/v1/push"
         }
       }
 
@@ -137,7 +139,7 @@ _: {
       // ============================================================================
       prometheus.remote_write "prometheus" {
         endpoint {
-          url = "http://discovery:9090/api/v1/write"
+          url = "http://${discoveryTs}:9090/api/v1/write"
         }
       }
     '';

--- a/modules/services/fleet-dns.nix
+++ b/modules/services/fleet-dns.nix
@@ -18,6 +18,10 @@ in {
     ...
   }: let
     cfg = config.services.fleetDns;
+    bindTarget =
+      if cfg.listenAddress == null
+      then cfg.interface
+      else cfg.listenAddress;
 
     # One CoreDNS server block per fleet.ingress zone: `template` answers every
     # A query CoreDNS routes here (i.e. anything matching `<zone>` or
@@ -26,7 +30,7 @@ in {
     # so it works even when that host's own resolver is down.
     zoneBlock = zone: hostIp: ''
       ${zone} {
-        bind ${cfg.interface}
+        bind ${bindTarget}
         template IN A {
           answer "{{ .Name }} 300 IN A ${hostIp}"
         }
@@ -43,6 +47,12 @@ in {
         type = lib.types.enum ["tailscale0" "enp5s0"];
         default = "tailscale0";
         description = "Interface on which CoreDNS listens and the firewall permits DNS.";
+      };
+
+      listenAddress = lib.mkOption {
+        type = lib.types.nullOr lib.types.singleLineStr;
+        default = null;
+        description = "Stable address for CoreDNS to bind; defaults to the selected interface.";
       };
 
       upstream = lib.mkOption {
@@ -86,7 +96,7 @@ in {
           )
           + ''
             . {
-              bind ${cfg.interface}
+              bind ${bindTarget}
               ${lib.optionalString (!cfg.sequentialUpstream) "forward . ${lib.concatStringsSep " " cfg.upstream}"}
               ${lib.optionalString cfg.sequentialUpstream ''
               forward . ${lib.concatStringsSep " " cfg.upstream} {

--- a/modules/services/vector-logs.nix
+++ b/modules/services/vector-logs.nix
@@ -1,4 +1,6 @@
-_: {
+{config, ...}: let
+  discoveryTs = config.fleet.hosts.discovery.tailscaleIp;
+in {
   # Lite journal→Loki shipper for storage/RAM-constrained hosts (e.g. the 1 GB
   # archinaut printer Pi) where the full Alloy agent is too heavy (~260 MB RSS
   # starved sshd during boot — see modules/services/alloy.nix). Vector idles at
@@ -30,7 +32,7 @@ _: {
           # Discovery's Loki over Tailscale MagicDNS (requires accept-dns +
           # tailnet ACL host -> discovery:3100, same as Alloy hosts). Vector
           # appends /loki/api/v1/push to this base endpoint itself.
-          endpoint = "http://discovery:3100";
+          endpoint = "http://${discoveryTs}:3100";
           # Match the fleet Alloy label set exactly (build-time hostname bake —
           # mirrors the alloy.nix journal labels).
           labels = {

--- a/modules/shell/_aliases.nix
+++ b/modules/shell/_aliases.nix
@@ -124,6 +124,9 @@ _: {
   hg = "herdr --remote gemini --session code";
   hgs = "ssh -t gemini 'exec herdr session attach code'";
   hl = "herdr session list";
+  hlab = "herdr --remote gemini --session homelab";
+  hdap = "herdr --remote gemini --session dataplatform";
+  hr = "herdr-repo";
   snix = "ssh -t gemini 'cd ~/Documents/erik/desktop-nixos && exec zsh -l'";
   sdp = "ssh -t gemini 'cd ~/Documents/nstech/dataplatform && exec zsh -l'";
   sspark = "ssh -t gemini 'cd ~/Documents/nstech/dataplatform-spark && exec zsh -l'";

--- a/tests/fleet-dns-lan/test_eval.py
+++ b/tests/fleet-dns-lan/test_eval.py
@@ -13,7 +13,8 @@ class FleetDnsEvalTest(unittest.TestCase):
 
     def test_generated_corefiles(self):
         kepler=self.value("kepler","services.coredns.config",True)
-        self.assertIn("bind enp5s0",kepler);self.assertIn("template IN AAAA",kepler)
+        self.assertIn("bind 192.168.10.230",kepler);self.assertIn("template IN AAAA",kepler)
+        self.assertNotIn("bind enp5s0",kepler)
         self.assertIn("forward . 192.168.10.210 1.1.1.1 9.9.9.9",kepler)
         self.assertIn("policy sequential",kepler);self.assertNotIn("\n  log\n",kepler)
         vanguard=self.value("vanguard","services.coredns.config",True)

--- a/tests/fleet-dns-lan/test_fleet_dns_lan.py
+++ b/tests/fleet-dns-lan/test_fleet_dns_lan.py
@@ -8,9 +8,14 @@ VANGUARD=(ROOT/"modules/hosts/vanguard/default.nix").read_text()
 class FleetDnsLanTest(unittest.TestCase):
     def test_interface_option_defaults_to_vanguard_tailnet(self):
         self.assertRegex(MODULE,r'interface\s*=\s*lib\.mkOption\s*\{[^}]*default\s*=\s*"tailscale0";')
-        self.assertIn('bind ${cfg.interface}',MODULE)
+        self.assertIn('bind ${bindTarget}',MODULE)
         self.assertRegex(MODULE,r'networking\.firewall\.interfaces\.\$\{cfg\.interface\}\s*=\s*\{[^}]*allowedTCPPorts\s*=\s*\[53\];[^}]*allowedUDPPorts\s*=\s*\[53\];')
         self.assertNotRegex(MODULE,r'networking\.firewall\.allowed(?:TCP|UDP)Ports\s*=')
+
+    def test_kepler_binds_stable_address_instead_of_racing_dhcp(self):
+        self.assertIn('listenAddress = lib.mkOption',MODULE)
+        self.assertIn('bindTarget =',MODULE)
+        self.assertIn('listenAddress = config.flake.fleet.hosts.kepler.ip;',KEPLER)
 
     def test_sequential_forward_is_opt_in_and_kepler_orders_adguard_first(self):
         self.assertRegex(MODULE,r'sequentialUpstream\s*=\s*lib\.mkEnableOption')
@@ -18,7 +23,7 @@ class FleetDnsLanTest(unittest.TestCase):
         self.assertIn('lib.optionalString cfg.sequentialUpstream',MODULE)
         self.assertIn('policy sequential',MODULE)
         self.assertIn('m.nixos.fleet-dns',KEPLER)
-        self.assertRegex(KEPLER,r'services\.fleetDns\s*=\s*\{[^}]*enable\s*=\s*true;[^}]*interface\s*=\s*"enp5s0";[^}]*upstream\s*=\s*\["192\.168\.10\.210"\s+"1\.1\.1\.1"\s+"9\.9\.9\.9"\];[^}]*sequentialUpstream\s*=\s*true;')
+        self.assertRegex(KEPLER,r'services\.fleetDns\s*=\s*\{[^}]*enable\s*=\s*true;[^}]*interface\s*=\s*"enp5s0";[^}]*listenAddress\s*=\s*config\.flake\.fleet\.hosts\.kepler\.ip;[^}]*upstream\s*=\s*\["192\.168\.10\.210"\s+"1\.1\.1\.1"\s+"9\.9\.9\.9"\];[^}]*sequentialUpstream\s*=\s*true;')
 
     def test_vanguard_keeps_default_tailnet_behavior(self):
         self.assertIn('services.fleetDns.enable = true;',VANGUARD)

--- a/tests/herdr-gemini/test_config.py
+++ b/tests/herdr-gemini/test_config.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+MODULE = ROOT / "modules/dev/herdr-gemini.nix"
+
+
+def test_gemini_owns_pinned_plugins_and_default_sessions():
+    source = MODULE.read_text()
+
+    assert 'plusVersion = "0.1.20"' in source
+    assert 'navigatorVersion = "0.3.3"' in source
+    assert '"homelab" "dataplatform"' in source
+    assert 'ExecStart = "${herdr}/bin/herdr --session %i server"' in source
+
+
+def test_repo_launcher_creates_persistent_remote_named_session():
+    source = MODULE.read_text()
+    herdr = (ROOT / "modules/dev/herdr.nix").read_text()
+
+    assert 'name = "herdr-repo"' in herdr
+    assert "rev-parse --show-toplevel" in herdr
+    assert "herdr-repo-bootstrap" in herdr
+    assert "systemctl --user enable --now" in source
+    assert 'workspace create --cwd "$remote_repo"' in source
+    assert 'exec herdr --remote gemini --session "$session"' in herdr
+
+
+def test_navigation_uses_plus_projects_and_one_global_picker():
+    source = MODULE.read_text()
+
+    herdr = (ROOT / "modules/dev/herdr.nix").read_text()
+
+    assert 'cloudmanic.herdr-plus.projects' in herdr
+    assert 'herdr-navigator.open' in herdr
+    assert 'key = "prefix+t"' in herdr
+    assert 'homelab = "~/Documents/erik/homelab"' in source
+    assert 'dataplatform = "~/Documents/nstech/dataplatform"' in source
+
+
+def test_gemini_imports_remote_session_profile_with_linger():
+    gemini = (ROOT / "modules/hosts/orion/gemini.nix").read_text()
+
+    assert "m.home.herdr-gemini" in gemini
+    assert "linger = true;" in gemini
+
+
+def test_shared_aliases_expose_default_and_repo_sessions():
+    aliases = (ROOT / "modules/shell/_aliases.nix").read_text()
+
+    assert 'hlab = "herdr --remote gemini --session homelab";' in aliases
+    assert 'hdap = "herdr --remote gemini --session dataplatform";' in aliases
+    assert 'hr = "herdr-repo";' in aliases

--- a/tests/monitoring-hardening/test_config.py
+++ b/tests/monitoring-hardening/test_config.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+
+
+def test_monitoring_refuses_to_start_without_vault_mount():
+    config = (ROOT / "modules/hosts/discovery/compose.nix").read_text()
+
+    assert 'podman-compose-monitoring' in config
+    assert 'mountpoint --quiet /home/erik/vault' in config
+
+
+def test_alloy_pushes_to_discovery_tailnet_ip():
+    config = (ROOT / "modules/services/alloy.nix").read_text()
+
+    assert "config.fleet.hosts.discovery.tailscaleIp" in config
+    assert 'http://${discoveryTs}:3100/loki/api/v1/push' in config
+    assert 'http://${discoveryTs}:9090/api/v1/write' in config
+
+
+def test_vector_pushes_to_discovery_tailnet_ip():
+    config = (ROOT / "modules/services/vector-logs.nix").read_text()
+
+    assert "config.fleet.hosts.discovery.tailscaleIp" in config
+    assert 'endpoint = "http://${discoveryTs}:3100"' in config
+
+
+def test_monitoring_health_gate_includes_metrics_and_logs_backends():
+    config = (ROOT / "modules/hosts/discovery/compose.nix").read_text()
+
+    assert (
+        'secretSpecRuntimeHealthContainers.monitoring = '
+        '["prometheus" "grafana" "loki" "healthchecks" "scrutiny-influxdb" "scrutiny"];'
+    ) in config

--- a/tests/p3-adguard-outage/test_parent_snapshot.py
+++ b/tests/p3-adguard-outage/test_parent_snapshot.py
@@ -29,7 +29,7 @@ def normalize_routes(value):
 
 class ParentSnapshot(unittest.TestCase):
     def test_lifetime_and_route_expiry_changes_are_ignored(self):
-        address = [{"ifname": "eno1", "address": "00:11:22:33:44:55", "mtu": 1500, "flags": ["UP", "LOWER_UP"], "addr_info": [{"family": "inet", "local": "192.168.10.125", "prefixlen": 24, "scope": "global", "label": "eno1", "valid_life_time": 100, "preferred_life_time": 50}]}]
+        address = [{"ifname": "eno1", "address": "00:11:22:33:44:55", "mtu": 1500, "flags": ["UP", "LOWER_UP"], "addr_info": [{"family": "inet", "local": "192.168.10.215", "prefixlen": 24, "scope": "global", "label": "eno1", "valid_life_time": 100, "preferred_life_time": 50}]}]
         route = [{"dst": "default", "gateway": "192.168.10.1", "dev": "eno1", "protocol": "dhcp", "expires": 100, "cache": ["x"], "used": 4, "lastuse": 3}]
         changed_address = copy.deepcopy(address); changed_address[0]["addr_info"][0]["valid_life_time"] = 99
         changed_route = copy.deepcopy(route); changed_route[0].update(expires=99, used=5, lastuse=4)
@@ -37,7 +37,7 @@ class ParentSnapshot(unittest.TestCase):
         self.assertEqual(normalize_routes(route), normalize_routes(changed_route))
 
     def test_stable_address_and_route_drift_is_rejected(self):
-        address = [{"ifname": "eno1", "address": "00:11:22:33:44:55", "mtu": 1500, "flags": ["UP"], "addr_info": [{"family": "inet", "local": "192.168.10.125", "prefixlen": 24, "scope": "global", "label": "eno1"}]}]
+        address = [{"ifname": "eno1", "address": "00:11:22:33:44:55", "mtu": 1500, "flags": ["UP"], "addr_info": [{"family": "inet", "local": "192.168.10.215", "prefixlen": 24, "scope": "global", "label": "eno1"}]}]
         changed_address = copy.deepcopy(address); changed_address[0]["addr_info"][0]["prefixlen"] = 25
         route = [{"dst": "default", "gateway": "192.168.10.1", "dev": "eno1", "protocol": "dhcp"}]
         changed_route = copy.deepcopy(route); changed_route[0]["gateway"] = "192.168.10.254"


### PR DESCRIPTION
## Summary
- harden Alloy ingestion limits and queue behavior
- bind Kepler CoreDNS to its stable LAN address and update Pathfinder addressing
- persist Herdr Gemini sessions and pin required plugins

## Verification
- targeted pytest suites: 26 passed
- `just docs-check`
- `just lint`
- `just fmt-check`
- `git diff --check origin/main...HEAD`
- `just dry-all` (running; fleet evaluation passed, closure realization in progress)