### PR TITLE
Recover Discovery from ESP reinstall

### DIFF
--- a/justfile
+++ b/justfile
@@ -2158,9 +2158,14 @@ mirror-kindle version digest:
       echo "invalid digest: {{digest}}" >&2
       exit 1
     }
+    skopeo="$(nix eval --raw .#nixosConfigurations.discovery.pkgs.skopeo.outPath)"
+    cosign="$(nix eval --raw .#nixosConfigurations.discovery.pkgs.cosign.outPath)"
+    tools_path="$skopeo/bin:$cosign/bin"
     IP="$(just _host-ip discovery)"
-    ssh -p 2222 erik@"$IP" sudo bash -s -- "{{version}}" "{{digest}}" <<'REMOTE'
+    ssh -p 2222 erik@"$IP" sudo env "TOOLS_PATH=$tools_path" \
+      bash -s -- "{{version}}" "{{digest}}" <<'REMOTE'
       set -euo pipefail
+      export PATH="$TOOLS_PATH:$PATH"
       env_file=/run/vault-agent/harbor.env
       export HARBOR_ROBOT_USER="$(sed -n 's/^HARBOR_ROBOT_USER=//p' "$env_file")"
       export HARBOR_ROBOT_SECRET="$(sed -n 's/^HARBOR_ROBOT_SECRET=//p' "$env_file")"
@@ -2401,6 +2406,23 @@ grafana-alert-retry target:
       [ -n "$ip" ] || ip="$(just _host-ip "$host")"
       ssh -p 2222 -o BatchMode=yes -o ConnectTimeout=8 "erik@$ip" "$command"
     fi
+
+# Pause the Discovery Telstar capacity retry while its remote state is repaired.
+pause-discovery-telstar:
+    ssh -p 2222 erik@{{ip_discovery}} 'sudo systemctl stop telstar-capture.service; sudo systemctl reset-failed telstar-capture.service'
+
+# Compare encrypted Telstar state copies without printing state content.
+discovery-telstar-state-inventory:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    inspect() {
+      local host=$1 ip=$2 path=$3
+      printf 'host=%s ' "$host"
+      ssh -p 2222 erik@"$ip" "if test -f '$path'; then stat -c 'bytes=%s mtime=%y' '$path'; sha256sum '$path'; else echo state=missing; fi"
+    }
+    inspect discovery {{ip_discovery}} /home/erik/tofu-state-export/oracle/compute-telstar/terraform.tfstate
+    inspect orion {{ip_orion}} /home/erik/tofu-state-backup/oracle/compute-telstar/terraform.tfstate
+    inspect kepler {{ip_kepler}} /home/erik/tofu-state-backup/oracle/compute-telstar/terraform.tfstate
 
 # After pulling, kick the compose stack on the remote host:
 #   just kick-stack kepler ai-serving
@@ -2997,6 +3019,10 @@ verify-hermes-secret-renders:
       sudo systemctl is-active hermes-wiki-clone.service
       echo "hermes_render=ready mode=0400 fresh=true files=4 wiki_owner=hermes"
     '
+
+# Read-only failure detail for the declarative Hermes wiki checkout.
+diagnose-hermes-wiki:
+    IP="$(just _host-ip discovery)"; ssh -p 2222 erik@"$IP" 'sudo systemctl status hermes-wiki-clone.service --no-pager -l || true; sudo journalctl -u hermes-wiki-clone.service -b --no-pager -n 100'
 
 # Refresh the OpenBao snapshot across every declared tier, then prove restore.
 backup-discovery-openbao-d4:
@@ -6081,6 +6107,463 @@ backup-discovery-identity-kepler:
       "$(date --iso-8601=seconds)"
     echo ":: PASS: encrypted Discovery host identities restored and hash-verified"
 
+# Restore the pinned D5 host-identity snapshot before stateful services resume.
+restore-discovery-identity-kepler:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    DISCOVERY="{{ip_discovery}}"
+    KEPLER="{{ip_kepler}}"
+    snapshot=868abf42
+    tailscale_sha256=c6a64318c4b5685b513056d22be3d91c25ae810d6d793c7a9fe400a22ff97c93
+    ssh_fingerprint='SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE'
+    password_file=$(mktemp)
+    restore=$(mktemp -d)
+    trap 'rm -f "$password_file"; rm -rf "$restore"' EXIT
+    ssh -p 2222 erik@"$DISCOVERY" \
+      'sudo cat /run/secrets/vault_restic_password' >"$password_file"
+    chmod 0600 "$password_file"
+    export RESTIC_PASSWORD_FILE="$password_file"
+    export RESTIC_REPOSITORY="sftp:erik@$KEPLER:/bulk/backups/discovery-esp-home"
+    sftp_cmd="ssh -p 2222 -o BatchMode=yes erik@$KEPLER -s sftp"
+    restic() {
+      nix shell --builders "{{orion_builder}}" --builders-use-substitutes \
+        --max-jobs 0 nixpkgs#restic -c restic -o "sftp.command=$sftp_cmd" "$@"
+    }
+    restic dump "$snapshot" discovery-host-identity.tar | tar -xpf - -C "$restore"
+    test "$(sha256sum "$restore/var/lib/tailscale/tailscaled.state" | awk '{print $1}')" = "$tailscale_sha256"
+    test "$(ssh-keygen -yf "$restore/etc/ssh/ssh_host_ed25519_key" |
+      ssh-keygen -lf - -E sha256 | awk '{print $2}')" = "$ssh_fingerprint"
+    ssh -p 2222 erik@"$DISCOVERY" '
+      sudo systemctl stop tailscaled-autoconnect.service tailscaled.service || true
+      sudo systemctl stop haos-vm.service docker.service docker.socket \
+        libvirtd.service openbao.service vault-agent.service || true
+    '
+    tar -C "$restore" -cpf - etc/ssh var/lib/tailscale home/erik/.config/sops |
+      ssh -p 2222 erik@"$DISCOVERY" 'sudo tar -C / -xpf -'
+    ssh -p 2222 erik@"$DISCOVERY" "TAILSCALE_SHA256=$tailscale_sha256 SSH_FINGERPRINT=$ssh_fingerprint bash -s" <<'REMOTE'
+      set -euo pipefail
+      sudo chmod 0600 /etc/ssh/ssh_host_ed25519_key /var/lib/tailscale/tailscaled.state
+      sudo chown -R erik:users /home/erik/.config/sops
+      sudo chmod 0600 /home/erik/.config/sops/age/keys.txt
+      sudo ssh-keygen -y -f /etc/ssh/ssh_host_ed25519_key |
+        sudo tee /etc/ssh/ssh_host_ed25519_key.pub >/dev/null
+      sudo chmod 0644 /etc/ssh/ssh_host_ed25519_key.pub
+      test "$(sudo sha256sum /var/lib/tailscale/tailscaled.state | awk '{print $1}')" = "$TAILSCALE_SHA256"
+      test "$(sudo ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub -E sha256 | awk '{print $2}')" = "$SSH_FINGERPRINT"
+      sudo /run/current-system/activate
+      sudo systemctl restart tailscaled.service
+      sudo systemctl restart sshd.service
+      test "$(tailscale status --json | jq -r .BackendState)" = Running
+    REMOTE
+    echo ":: PASS: Discovery SSH, Tailscale, and sops identities restored"
+
+# Verify the new boot storage and preserved vault before state restoration.
+verify-discovery-postinstall-storage:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ssh -p 2222 erik@{{ip_discovery}} 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      esp=$(readlink -f /dev/disk/by-id/ata-KINGSTON_SA400S37480G_AA000000000000000105-part1)
+      primary=$(readlink -f /dev/disk/by-id/ata-KINGSTON_SA400S37480G_AA000000000000000105-part2)
+      mirror=$(readlink -f /dev/disk/by-id/ata-KINGSTON_SA400S37480G_AA000000000000000098-part1)
+      vault=$(readlink -f /dev/disk/by-id/ata-ST4000DM004-2CV104_ZTT25R4M-part1)
+      for mount in /boot /home/erik/vault; do
+        findmnt -nro TARGET,SOURCE,FSTYPE,UUID "$mount"
+      done
+      sudo btrfs filesystem show /
+      sudo btrfs filesystem usage -b /
+      systemctl is-active docker.service libvirtd.service openbao.service || true
+      test "$(findmnt -nro SOURCE /boot)" = "$esp"
+      test "$(findmnt -bnro SIZE /boot)" -ge 2000000000
+      test "$(findmnt -nro FSTYPE /boot)" = vfat
+      test "$(findmnt -nro UUID /home/erik/vault)" = d026033d-158d-49ca-9ff9-dd2d5c8a21dc
+      test "$(findmnt -nro SOURCE /home/erik/vault)" = "$vault"
+      devices=$(sudo btrfs filesystem show /)
+      grep -Fq "path $primary" <<<"$devices"
+      grep -Fq "path $mirror" <<<"$devices"
+      sudo btrfs filesystem usage -b / | grep -Eq "^Data,RAID1:"
+      sudo btrfs filesystem usage -b / | grep -Eq "^Metadata,RAID1:"
+      test "$(systemctl is-active docker.service 2>/dev/null || true)" = inactive
+      test "$(systemctl is-active libvirtd.service 2>/dev/null || true)" = inactive
+      test "$(systemctl is-active openbao.service 2>/dev/null || true)" = inactive
+    REMOTE
+    echo ":: PASS: Discovery ESP, Btrfs RAID1, and vault identities verified"
+
+# Restore the pinned D5 mutable-state archive, then re-apply Home Manager.
+restore-discovery-home-kepler:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    DISCOVERY="{{ip_discovery}}"
+    KEPLER="{{ip_kepler}}"
+    snapshot=6943b508
+    password_file=$(mktemp)
+    trap 'rm -f "$password_file"' EXIT
+    ssh -p 2222 erik@"$DISCOVERY" 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      sudo systemctl stop haos-vm.service docker.service docker.socket \
+        libvirtd.service libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket \
+        openbao.service vault-agent.service || true
+      test "$(findmnt -nro UUID /home/erik/vault)" = d026033d-158d-49ca-9ff9-dd2d5c8a21dc
+      test "$(systemctl is-active docker.service 2>/dev/null || true)" = inactive
+      test "$(systemctl is-active libvirtd.service 2>/dev/null || true)" = inactive
+      test "$(systemctl is-active openbao.service 2>/dev/null || true)" = inactive
+    REMOTE
+    ssh -p 2222 erik@"$DISCOVERY" \
+      'sudo cat /run/secrets/vault_restic_password' >"$password_file"
+    chmod 0600 "$password_file"
+    export RESTIC_PASSWORD_FILE="$password_file"
+    export RESTIC_REPOSITORY="sftp:erik@$KEPLER:/bulk/backups/discovery-esp-home"
+    sftp_cmd="ssh -p 2222 -o BatchMode=yes erik@$KEPLER -s sftp"
+    restic() {
+      nix shell --builders "{{orion_builder}}" --builders-use-substitutes \
+        --max-jobs 0 nixpkgs#restic -c restic -o "sftp.command=$sftp_cmd" "$@"
+    }
+    restic snapshots "$snapshot" >/dev/null
+    restic dump "$snapshot" discovery-mutable-state.tar |
+      ssh -p 2222 erik@"$DISCOVERY" 'sudo tar -C / -xpf -'
+    ssh -p 2222 erik@"$DISCOVERY" 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      for path in \
+        /home/erik/.config/sops/age/keys.txt \
+        /home/erik/servarr/machines/discovery/.env.sops \
+        /home/erik/servarr/machines/discovery/config/swag/nginx/proxy-confs/harbor.subdomain.conf \
+        /home/erik/homelab/apps/netbird/pocket-id/pocket-id.db \
+        /home/erik/servarr/README.md; do
+        sudo test -s "$path"
+      done
+      test "$(sudo ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub -E sha256 | awk '{print $2}')" = \
+        'SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE'
+      sudo systemctl restart home-manager-erik.service
+      systemctl is-active --quiet home-manager-erik.service
+    REMOTE
+    echo ":: PASS: Discovery mutable home and SSH state restored from 6943b508"
+
+# Hold stateful substrates down across dependency-triggered restarts.
+quiesce-discovery-restore:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ssh -p 2222 erik@{{ip_discovery}} 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      units=(
+        haos-vm.service
+        docker.service docker.socket docker-recover.service docker-recover.timer
+        libvirtd.service libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket
+        openbao.service openbao-unseal.service openbao-unseal.timer
+        vault-agent.service
+      )
+      sudo systemctl mask --runtime --now "${units[@]}"
+      sudo systemctl stop "${units[@]}" || true
+      sudo systemctl reset-failed "${units[@]}" || true
+      for unit in docker.service libvirtd.service openbao.service vault-agent.service; do
+        test "$(systemctl is-active "$unit" 2>/dev/null || true)" = inactive
+      done
+    REMOTE
+    echo ":: PASS: Discovery stateful substrates runtime-masked for restore"
+
+# Retain a failed fresh-cluster init before retrying the pinned snapshot restore.
+quarantine-discovery-openbao-throwaway:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ssh -p 2222 erik@{{ip_discovery}} 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      source=/var/lib/private/openbao
+      retained=/var/lib/private/openbao-d5-throwaway
+      if sudo test -d "$source" && sudo test ! -e "$retained"; then
+        bytes=$(sudo du -sb /var/lib/private/openbao | awk '{print $1}')
+        printf 'throwaway_bytes=%s state=%s\n' "$bytes" "$(systemctl is-active openbao.service 2>/dev/null || true)"
+        test "$bytes" -lt 67108864
+        export BAO_ADDR=http://127.0.0.1:8200
+        ! BAO_TOKEN=$(sudo cat /run/secrets/vault_snapshot_token) \
+          bao kv metadata get secret/shared/discord >/dev/null 2>&1
+        sudo systemctl mask --runtime --now openbao.service
+        sudo systemctl stop openbao.service || true
+        sudo mv /var/lib/private/openbao "$retained"
+      else
+        sudo test -d "$retained"
+        sudo test ! -e "$source"
+        bytes=$(sudo du -sb "$retained" | awk '{print $1}')
+      fi
+      sudo install -d -m 0700 -o root -g root "$source"
+      printf 'retained=%s bytes=%s\n' "$retained" "$bytes"
+    REMOTE
+    echo ":: PASS: failed throwaway OpenBao cluster retained; fresh state ready"
+
+# Restore the pinned D4 OpenBao snapshot into a fresh node and prove metadata.
+restore-discovery-openbao:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    RESTIC="$(nix eval --raw .#nixosConfigurations.discovery.pkgs.restic.outPath)/bin/restic"
+    ssh -p 2222 erik@{{ip_discovery}} "RESTIC=$RESTIC bash -s" <<'REMOTE'
+      set -euo pipefail
+      snapshot=315ed0ea
+      expected_sha256=8407ae773697c8511a6d2f2a24f0152dd547a91e7115148c8ecebea4f989ba29
+      repository=/home/erik/vault/restic/openbao
+      work=/var/lib/vault-snapshots/d5-restore-315ed0ea-v2
+      sudo install -d -m 0700 -o root -g root "$work"
+      test "$(findmnt -nro UUID /home/erik/vault)" = d026033d-158d-49ca-9ff9-dd2d5c8a21dc
+      snap="$work/var/lib/vault-snapshots/openbao.snap"
+      if ! sudo test -s "$snap"; then
+        sudo env RESTIC_PASSWORD_FILE=/run/secrets/vault_restic_password \
+          "$RESTIC" -r "$repository" restore "$snapshot" --target "$work"
+      fi
+      test "$(sudo sha256sum "$snap" | awk '{print $1}')" = "$expected_sha256"
+      sudo chown -R erik:users "$work"
+      chmod 0700 "$work"
+      chmod 0600 "$snap"
+
+      if ! ip link show br-openbao >/dev/null 2>&1; then
+        sudo ip link add name br-openbao type bridge
+      fi
+      if ! ip -4 address show dev br-openbao | grep -Fq '172.31.82.1/29'; then
+        sudo ip address add 172.31.82.1/29 dev br-openbao
+      fi
+      sudo ip link set br-openbao up
+      sudo systemctl unmask --runtime openbao.service
+      sudo systemctl reset-failed openbao.service
+      if ! sudo systemctl start openbao.service; then
+        sudo systemctl status openbao.service --no-pager -l || true
+        sudo journalctl -u openbao.service -b --no-pager -n 100
+        exit 1
+      fi
+      for _ in $(seq 1 60); do
+        curl -sS -m 1 http://127.0.0.1:8200/v1/sys/health >/dev/null 2>&1 && break
+        sleep 0.5
+      done
+      export BAO_ADDR=http://127.0.0.1:8200
+      initialized=$(curl -fsS -m 10 http://127.0.0.1:8200/v1/sys/seal-status |
+        jq -r '.initialized')
+      if test "$initialized" = false; then
+        init_json=$(bao operator init -key-shares=1 -key-threshold=1 -format=json)
+        throwaway_key=$(jq -r '.unseal_keys_b64[0]' <<<"$init_json")
+        throwaway_token=$(jq -r '.root_token' <<<"$init_json")
+        unset init_json
+        bao operator unseal "$throwaway_key" >/dev/null
+        BAO_TOKEN="$throwaway_token" bao operator raft snapshot restore -force "$snap"
+        unset throwaway_key throwaway_token
+      fi
+
+      echo stage=seal-status
+      sealed=$(curl -fsS -m 10 http://127.0.0.1:8200/v1/sys/seal-status |
+        jq -r '.sealed')
+      if test "$sealed" = true; then
+        unseal_key=$(sudo cat /run/secrets/vault_unseal_key)
+        jq -n --arg key "$unseal_key" '{key: $key}' |
+          curl -fsS -m 10 -X PUT --data @- http://127.0.0.1:8200/v1/sys/unseal >/dev/null
+        unset unseal_key
+      fi
+      curl -fsS -m 10 http://127.0.0.1:8200/v1/sys/seal-status |
+        jq -e '.initialized == true and .sealed == false' >/dev/null
+      echo stage=approle-login
+      role_id=$(sudo cat /run/secrets/vault_agent_role_id)
+      secret_id=$(sudo cat /run/secrets/vault_agent_secret_id)
+      login_json=$(jq -n --arg role_id "$role_id" --arg secret_id "$secret_id" \
+        '{role_id: $role_id, secret_id: $secret_id}' |
+        curl -fsS -m 10 -X POST --data @- http://127.0.0.1:8200/v1/auth/approle/login)
+      unset role_id secret_id
+      client_token=$(jq -er '.auth.client_token' <<<"$login_json")
+      unset login_json
+      echo stage=kv-proof
+      BAO_TOKEN="$client_token" bao kv get -format=json secret/shared/discord |
+        jq -e '.data.data | length > 0' >/dev/null
+      unset client_token
+
+      sudo systemctl unmask --runtime openbao-unseal.service openbao-unseal.timer vault-agent.service
+      sudo systemctl start openbao-unseal.timer
+      echo stage=vault-agent
+      sudo systemctl start vault-agent.service
+      for path in \
+        /run/vault-agent/discord_webhook_incidents \
+        /run/vault-agent/networking.env \
+        /run/vault-agent/shared-db.env; do
+        for _ in $(seq 1 100); do
+          sudo test -s "$path" && break
+          sleep 0.1
+        done
+        sudo test -s "$path"
+      done
+    REMOTE
+    echo ":: PASS: OpenBao snapshot 315ed0ea restored, unsealed, and rendered"
+
+# Restore the stopped Docker mirror, retaining the reinstall's fresh root.
+restore-discovery-docker:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    evidence=.gsd/evidence/discovery-esp/manifest.json
+    jq -e '
+      .approval_ready == true
+      and .backups.docker.cold_mirror == "/home/erik/vault/migration/discovery-docker-root"
+      and .backups.docker.scratch_restore == "passed"
+      and .backups.docker.metadata_sha256 == "a654304de8d8a29b1986b8ba9f2b3c19a87d58b58768b60c766d4e621ead42b5"
+    ' "$evidence" >/dev/null
+    evidence_sha=$(sha256sum "$evidence" | cut -d' ' -f1)
+    ssh -p 2222 erik@{{ip_discovery}} "EVIDENCE_SHA=$evidence_sha bash -s" <<'REMOTE'
+      set -euo pipefail
+      source=/home/erik/vault/migration/discovery-docker-root
+      marker=/home/erik/vault/migration/discovery-docker-root.final
+      destination=/var/lib/docker
+      retained=/var/lib/docker-d5-fresh
+      echo stage=preflight
+      vault_uuid=$(findmnt -nro UUID /home/erik/vault)
+      marker_state=$(sudo test -s "$marker" && echo present || echo absent)
+      source_state=$(sudo test -d "$source" && echo present || echo absent)
+      printf 'vault_uuid=%s marker=%s source=%s docker=%s socket=%s\n' \
+        "$vault_uuid" "$marker_state" "$source_state" \
+        "$(systemctl is-active docker.service 2>/dev/null || true)" \
+        "$(systemctl is-active docker.socket 2>/dev/null || true)"
+      [[ "$EVIDENCE_SHA" =~ ^[0-9a-f]{64}$ ]]
+      test "$vault_uuid" = d026033d-158d-49ca-9ff9-dd2d5c8a21dc
+      sudo test -d "$source"
+      source_bytes=$(sudo du -xsb "$source" | awk '{print $1}')
+      test "$source_bytes" -gt 10737418240
+      test "$(sudo find "$source/containers" -name config.v2.json -print -quit)" != ""
+      docker_units=(
+        docker.service docker.socket docker-recover.service docker-recover.timer
+      )
+      hold_units=(docker.service docker.socket)
+      for unit in "${hold_units[@]}"; do
+        sudo install -d -m 0755 "/run/systemd/system/$unit.d"
+        printf '%s\n' \
+          '[Unit]' \
+          'ConditionPathExists=/run/discovery-docker-restore-start-allowed' |
+          sudo tee "/run/systemd/system/$unit.d/d5-restore.conf" >/dev/null
+      done
+      sudo systemctl daemon-reload
+      sudo systemctl mask --runtime --now "${docker_units[@]}" || true
+      sudo systemctl stop "${docker_units[@]}" || true
+      sudo systemctl reset-failed "${docker_units[@]}" || true
+      test "$(systemctl is-active docker.service 2>/dev/null || true)" = inactive
+      test "$(systemctl is-active docker.socket 2>/dev/null || true)" = inactive
+      echo stage=retain
+      if sudo test ! -e "$retained"; then
+        fresh_bytes=$(sudo du -xsb "$destination" | awk '{print $1}')
+        test "$fresh_bytes" -lt 1073741824
+        sudo mv "$destination" "$retained"
+      else
+        sudo test -d "$retained"
+      fi
+      sudo install -d -m 0710 -o root -g docker "$destination"
+      echo stage=rsync
+      sudo rsync -aHAXx --numeric-ids --delete --stats "$source/" "$destination/"
+      test "$(systemctl is-active docker.service 2>/dev/null || true)" = inactive
+      test "$(systemctl is-active docker.socket 2>/dev/null || true)" = inactive
+      drift=$(sudo rsync -aHAXxni --numeric-ids --delete "$source/" "$destination/")
+      test -z "$drift" || { printf '%s\n' "$drift" >&2; exit 1; }
+      echo stage=manifest
+      source_manifest=$(sudo find "$source" -xdev ! -type d -printf '%P\t%y\t%s\t%m\t%U\t%G\n' |
+        LC_ALL=C sort | sha256sum | cut -d' ' -f1)
+      destination_manifest=$(sudo find "$destination" -xdev ! -type d -printf '%P\t%y\t%s\t%m\t%U\t%G\n' |
+        LC_ALL=C sort | sha256sum | cut -d' ' -f1)
+      expected_manifest=$source_manifest
+      test "$source_manifest" = "$expected_manifest"
+      test "$destination_manifest" = "$expected_manifest"
+      echo stage=start
+      retained_hold=/run/discovery-docker-restore-hold
+      sudo install -d -m 0700 "$retained_hold"
+      for unit in "${hold_units[@]}"; do
+        sudo mv "/run/systemd/system/$unit.d/d5-restore.conf" \
+          "$retained_hold/$unit.$$.conf"
+      done
+      sudo systemctl daemon-reload
+      sudo systemctl unmask --runtime docker.service docker.socket
+      sudo systemctl reset-failed docker.service docker.socket
+      sudo systemctl start docker.service || true
+      for _ in $(seq 1 300); do
+        systemctl is-active --quiet docker.service && break
+        sleep 1
+      done
+      if ! systemctl is-active --quiet docker.service; then
+        sudo systemctl status docker.service docker.socket --no-pager -l || true
+        sudo journalctl -u docker.service -b --no-pager -n 100
+        exit 1
+      fi
+      test "$(sudo docker info --format '{{"{{"}}.DockerRootDir{{"}}"}}')" = /var/lib/docker
+      printf 'containers=%s images=%s manifest_sha256=%s\n' \
+        "$(sudo docker ps -aq | wc -l)" "$(sudo docker images -q | sort -u | wc -l)" \
+        "$destination_manifest"
+    REMOTE
+    echo ":: PASS: Docker cold mirror restored exactly; fresh root retained"
+
+# Resume Nix-owned stateful services after OpenBao and Docker restoration.
+resume-discovery-postrestore-substrates:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ssh -p 2222 erik@{{ip_discovery}} 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      units=(
+        docker-recover.service docker-recover.timer
+        openbao-unseal.service openbao-unseal.timer
+        libvirtd.service libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket
+        haos-vm.service
+      )
+      sudo systemctl unmask --runtime "${units[@]}"
+      sudo systemctl reset-failed "${units[@]}" harbor.service
+      sudo systemctl start docker-recover.timer openbao-unseal.timer
+      sudo systemctl start docker-recover.service
+      sudo systemctl start libvirtd.service
+      sudo systemctl restart harbor.service
+      harbor_healthy=false
+      for _ in $(seq 1 180); do
+        if curl -fsS -m 3 http://127.0.0.1:8085/api/v2.0/health |
+          jq -e '.status == "healthy"' >/dev/null 2>&1; then
+          harbor_healthy=true
+          break
+        fi
+        sleep 1
+      done
+      "$harbor_healthy"
+      sudo systemctl start haos-vm.service
+      haos_running=false
+      for _ in $(seq 1 120); do
+        if sudo virsh domstate haos | grep -Fx running >/dev/null 2>&1; then
+          haos_running=true
+          break
+        fi
+        sleep 1
+      done
+      "$haos_running"
+      systemctl is-active docker.service libvirtd.service openbao.service \
+        vault-agent.service harbor.service
+      BAO_ADDR=http://127.0.0.1:8200 bao status | grep -Eq '^Sealed[[:space:]]+false$'
+      sudo virsh domstate haos | grep -Fx running
+    REMOTE
+    echo ":: PASS: Docker recovery, unseal, Harbor, libvirt, and HAOS resumed"
+
+# Re-run NetBird's render-first boot ordering after Docker restoration.
+resume-discovery-netbird:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ssh -p 2222 erik@{{ip_discovery}} 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      units=(
+        netbird-management-config.service
+        docker-netbird-pocketid.service
+        docker-netbird-management.service
+        docker-netbird-signal.service
+        docker-netbird-dashboard.service
+        docker-netbird-relay.service
+      )
+      sudo systemctl reset-failed "${units[@]}"
+      sudo systemctl restart netbird-management-config.service
+      sudo systemctl restart docker-netbird-pocketid.service
+      sudo systemctl restart docker-netbird-management.service
+      sudo systemctl restart docker-netbird-signal.service
+      sudo systemctl restart docker-netbird-dashboard.service
+      sudo systemctl restart docker-netbird-relay.service
+      systemctl is-active "${units[@]}"
+      oidc_ready=false
+      for _ in $(seq 1 60); do
+        if curl -fsS -m 5 \
+          https://id.homelab.pastelariadev.com/.well-known/openid-configuration \
+          >/dev/null; then
+          oidc_ready=true
+          break
+        fi
+        sleep 1
+      done
+      "$oidc_ready"
+    REMOTE
+    echo ":: PASS: NetBird control plane resumed from fresh Vault renders"
+
 # Encrypt Discovery home/SSH state to Kepler and hash-verify seven restore classes.
 backup-discovery-home-kepler:
     #!/usr/bin/env bash
@@ -6411,6 +6894,32 @@ discovery-docker-mirror-finalize:
 
 # Read-only post-install acceptance gate. Run only after dependency-ordered
 # restoration has completed; it does not start or repair any service.
+diagnose-discovery-gpu:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    pciutils="$(nix eval --raw .#nixosConfigurations.discovery.pkgs.pciutils.outPath)"
+    ssh -p 2222 erik@{{ip_discovery}} "TOOLS_PATH=$pciutils/bin bash -s" <<'REMOTE'
+      export PATH="$TOOLS_PATH:$PATH"
+      echo ":: pci"
+      lspci -nnk | grep -A3 -Ei 'VGA|3D|NVIDIA' || true
+      echo ":: modules"
+      lsmod | grep -E '^nvidia' || true
+      echo ":: devices"
+      for device in /dev/nvidia*; do
+        test ! -e "$device" || stat -c '%n %a %U:%G' "$device"
+      done
+      echo ":: nvidia-smi"
+      nvidia-smi || true
+      echo ":: units"
+      systemctl status nvidia-persistenced.service \
+        nvidia-container-toolkit-cdi-generator.service --no-pager -l || true
+      echo ":: kernel"
+      journalctl -b -k --no-pager |
+        grep -Ei 'nvidia|nouveau|NVRM|BAR|IOMMU|firmware' | tail -120 || true
+    REMOTE
+
+# Read-only post-install acceptance gate. Run only after dependency-ordered
+# restoration has completed; it does not start or repair any service.
 verify-discovery-esp:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -6423,11 +6932,17 @@ verify-discovery-esp:
       test "$(sudo docker info --format '{{"{{"}}.DockerRootDir{{"}}"}}')" = /var/lib/docker
       sudo btrfs filesystem usage -b / | grep -Eq '^Data,RAID1:'
       sudo btrfs filesystem usage -b / | grep -Eq '^Metadata,RAID1:'
-      sudo systemctl is-active sshd tailscaled docker libvirtd openbao openbao-unseal vault-agent
+      sudo systemctl is-active sshd tailscaled docker libvirtd openbao vault-agent openbao-unseal.timer
+      test "$(systemctl show -p Result --value openbao-unseal.service)" = success
+      echo stage=openbao
       BAO_ADDR=http://127.0.0.1:8200 bao status | grep -Eq '^Sealed[[:space:]]+false$'
-      dig +short +time=3 +tries=1 @127.0.0.1 discovery.homelab.pastelariadev.com A | grep -Eq '^[0-9]+(\.[0-9]+){3}$'
+      echo stage=dns
+      dig +short +time=3 +tries=1 @{{ip_discovery}} discovery.homelab.pastelariadev.com A | grep -Eq '^[0-9]+(\.[0-9]+){3}$'
+      echo stage=grafana
       curl -kfsS -o /dev/null https://grafana.homelab.pastelariadev.com/
+      echo stage=haos
       sudo virsh domstate haos | grep -Fx running
+      echo stage=failed-units
       failed=$(systemctl --failed --no-legend | awk 'NF')
       printf '%s' "$failed"
       test -z "$failed"

--- a/justfile
+++ b/justfile
@@ -6035,6 +6035,52 @@ discovery-home-restore-preflight:
     REMOTE
     echo ":: PASS: mutable-state restore classes exist and Kepler has capacity"
 
+# Encrypt Discovery's host identities to Kepler and verify the restored hashes.
+backup-discovery-identity-kepler:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    DISCOVERY="{{ip_discovery}}"
+    KEPLER="{{ip_kepler}}"
+    samples=(
+      var/lib/tailscale/tailscaled.state
+      etc/ssh/ssh_host_ed25519_key
+      home/erik/.config/sops/age/keys.txt
+    )
+    password_file=$(mktemp)
+    hashes=$(mktemp)
+    restore=$(mktemp -d)
+    trap 'rm -f "$password_file" "$hashes"; rm -rf "$restore"' EXIT
+    ssh -p 2222 erik@"$DISCOVERY" \
+      'sudo cat /run/secrets/vault_restic_password' >"$password_file"
+    chmod 0600 "$password_file"
+    export RESTIC_PASSWORD_FILE="$password_file"
+    export RESTIC_REPOSITORY="sftp:erik@$KEPLER:/bulk/backups/discovery-esp-home"
+    sftp_cmd="ssh -p 2222 -o BatchMode=yes erik@$KEPLER -s sftp"
+    restic() {
+      nix shell --builders "{{orion_builder}}" --builders-use-substitutes \
+        --max-jobs 0 nixpkgs#restic -c restic -o "sftp.command=$sftp_cmd" "$@"
+    }
+    restic unlock
+    for sample in "${samples[@]}"; do
+      ssh -p 2222 erik@"$DISCOVERY" "sudo sha256sum '/$sample'" >>"$hashes"
+    done
+    ssh -p 2222 erik@"$DISCOVERY" \
+      "sudo tar -C / -cpf - ${samples[*]}" |
+      restic backup --stdin --stdin-filename discovery-host-identity.tar \
+        --tag discovery-esp-identity
+    snapshot=$(restic snapshots --tag discovery-esp-identity --latest 1 --json |
+      jq -r 'max_by(.time).short_id')
+    restic dump "$snapshot" discovery-host-identity.tar |
+      tar -xpf - -C "$restore"
+    while read -r expected path; do
+      actual=$(sha256sum "$restore/${path#/}" | awk '{print $1}')
+      test "$actual" = "$expected"
+    done <"$hashes"
+    printf 'snapshot=%s tailscale_sha256=%s verified_at=%s\n' \
+      "$snapshot" "$(awk '$2 == "/var/lib/tailscale/tailscaled.state" {print $1}' "$hashes")" \
+      "$(date --iso-8601=seconds)"
+    echo ":: PASS: encrypted Discovery host identities restored and hash-verified"
+
 # Encrypt Discovery home/SSH state to Kepler and hash-verify seven restore classes.
 backup-discovery-home-kepler:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -2998,6 +2998,31 @@ verify-hermes-secret-renders:
       echo "hermes_render=ready mode=0400 fresh=true files=4 wiki_owner=hermes"
     '
 
+# Refresh the OpenBao snapshot across every declared tier, then prove restore.
+backup-discovery-openbao-d4:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP="$(just _host-ip discovery)"
+    ssh -p 2222 erik@"$IP" 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      units=(
+        restic-backups-vault.service
+        restic-backups-vault-offsite.service
+        restic-backups-vault-rest.service
+        restic-backups-vault-b2.service
+      )
+      for unit in "${units[@]}"; do
+        sudo systemctl start "$unit"
+        sudo systemctl show "$unit" \
+          --property=Id,ExecMainStatus,ActiveEnterTimestamp --value |
+          paste -sd ' ' -
+      done
+      sudo sha256sum /var/lib/vault-snapshots/openbao.snap
+      sudo systemctl start openbao-restore-drill.service
+      test "$(systemctl show openbao-restore-drill.service --property=Result --value)" = success
+    REMOTE
+    echo ":: PASS: fresh OpenBao snapshot copied to every tier and restored"
+
 openbao-restore-drill:
     IP="$(just _host-ip discovery)"; ssh -p 2222 erik@"$IP" 'sudo systemctl start openbao-restore-drill.service && { sudo systemctl status openbao-restore-drill.service --no-pager || true; }'
 

--- a/justfile
+++ b/justfile
@@ -1596,6 +1596,15 @@ p3-dns-verify:
     '
     echo ":: P3 direct secondary OK — Kepler UDP/TCP fleet/external DNS healthy"
 
+# Read-only Kepler secondary-DNS failure detail.
+diagnose-kepler-dns:
+    ssh -p 2222 erik@{{ip_kepler}} 'sudo systemctl status coredns.service --no-pager -l; sudo systemctl show coredns.service -p ActiveState -p SubState -p Result -p NRestarts; sudo ss -H -lntup "sport = :53"; sudo journalctl -u coredns.service -b --no-pager -n 80'
+
+# Recover the existing listener after DHCP has assigned Kepler's LAN address.
+recover-kepler-dns:
+    ssh -p 2222 erik@{{ip_kepler}} 'sudo systemctl restart coredns.service'
+    just p3-dns-verify
+
 # P3 generic non-overlay client proof. Creates a temporary macvlan/netns on the
 # explicitly wired parent, acquires a real DHCP lease, verifies option 6 and
 # both resolvers, then proves the parent network is byte-for-byte unchanged.
@@ -5077,8 +5086,11 @@ discovery-postgres-restore-drill:
     scan=$(mktemp)
     trap 'rm -f "$scan"' EXIT
     ssh-keyscan -p 2222 {{ip_discovery}} >"$scan" 2>/dev/null
-    ssh-keygen -lf "$scan" -E sha256 |
-      grep -Fq 'SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE'
+    if ! ssh-keygen -lf "$scan" -E sha256 |
+      grep -Fq 'SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE'; then
+      ssh-keygen -lf "$scan" -E sha256
+      exit 1
+    fi
     hostkeys=$(base64 -w0 "$scan")
     ssh -p 2222 erik@{{ip_orion}} "HOSTKEYS=$hostkeys bash -s" <<'REMOTE'
       set -euo pipefail
@@ -5149,6 +5161,1141 @@ discovery-postgres-restore-drill-result:
       test -n "$latest"
       sudo cat "$latest"
     '
+
+# Prove the declared Redis cache layer starts empty without restored state.
+discovery-redis-cold-start-drill:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ssh -p 2222 erik@{{ip_orion}} 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      image='redis:8.8.0-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005'
+      name="discovery-redis-drill-$(date +%s)"
+      trap 'sudo docker rm -f "$name" >/dev/null 2>&1 || true' EXIT
+      sudo docker image inspect "$image" >/dev/null 2>&1 || sudo docker pull "$image"
+      sudo docker run -d --network none --name "$name" "$image" \
+        redis-server --requirepass drill-only >/dev/null
+      ready=false
+      for _ in $(seq 1 30); do
+        if sudo docker exec "$name" redis-cli -a drill-only PING 2>/dev/null |
+          grep -qx PONG; then
+          ready=true
+          break
+        fi
+        sleep 1
+      done
+      "$ready"
+      sudo docker inspect "$name" |
+        jq -e '.[0].HostConfig.NetworkMode == "none"' >/dev/null
+      for database in 0 1 2 3 4; do
+        keys=$(sudo docker exec "$name" redis-cli -a drill-only -n "$database" DBSIZE 2>/dev/null)
+        test "$keys" = 0
+        printf 'database=%s keys=%s\n' "$database" "$keys"
+      done
+    REMOTE
+    echo ":: PASS: isolated Redis cold-started empty; no production state restored"
+
+# Read-only state/schema gate before the isolated NetBird/PocketID rehearsal.
+discovery-netbird-state-preflight:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    sqlite3=$(nix eval --raw .#nixosConfigurations.discovery.pkgs.sqlite.outPath)/bin/sqlite3
+    ssh -p 2222 erik@{{ip_discovery}} "SQLITE3=$sqlite3 bash -s" <<'REMOTE'
+      set -euo pipefail
+      state=/home/erik/homelab/apps/netbird/pocket-id
+      test -d "$state"
+      test -x "$SQLITE3"
+      mapfile -t databases < <(find "$state" -maxdepth 1 -type f -name '*.db' -print)
+      test "${#databases[@]}" = 1
+      find "$state" -maxdepth 2 -type f -printf 'file=%P bytes=%s mode=%m uid=%U gid=%G\n' | sort
+      integrity=$("$SQLITE3" -readonly "${databases[0]}" 'PRAGMA integrity_check')
+      test "$integrity" = ok
+      printf 'integrity=%s\n' "$integrity"
+      "$SQLITE3" -readonly "${databases[0]}" \
+        "SELECT 'table=' || name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+      for container in netbird-pocketid netbird-management; do
+        unit="docker-$container.service"
+        state=$(systemctl is-active "$unit" 2>/dev/null || true)
+        printf 'unit=%s state=%s\n' "$unit" "$state"
+        if test "$state" != active; then
+          pgrep -af 'pocket-id' || true
+          sudo fuser -v "${databases[0]}" "${databases[0]}-wal" 2>&1 || true
+          sudo docker ps -a --format json |
+            jq -r 'select((.Image // "") | test("pocket-id|netbird")) | [.Names, .State, .Image] | @tsv' || true
+          sudo systemctl status "$unit" --no-pager -l -n 30 || true
+          sudo journalctl -u "$unit" --no-pager -n 50
+          exit 1
+        fi
+      done
+    REMOTE
+    echo ":: PASS: PocketID SQLite opens read-only and NetBird consumers exist"
+
+# Retry PocketID only after proving no live instance/file holder and a healthy DB.
+repair-netbird-pocketid:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    sqlite3=$(nix eval --raw .#nixosConfigurations.discovery.pkgs.sqlite.outPath)/bin/sqlite3
+    ssh -p 2222 erik@{{ip_discovery}} "SQLITE3=$sqlite3 bash -s" <<'REMOTE'
+      set -euo pipefail
+      database=/home/erik/homelab/apps/netbird/pocket-id/pocket-id.db
+      test -f "$database"
+      test "$("$SQLITE3" -readonly "$database" 'PRAGMA integrity_check')" = ok
+      if test "$(systemctl is-active docker-netbird-pocketid.service 2>/dev/null || true)" != active; then
+        if pgrep -af '/app/pocket-id'; then
+          echo ":: BLOCKED: PocketID process already exists" >&2
+          exit 1
+        fi
+        if sudo fuser "$database" "$database-wal" >/dev/null 2>&1; then
+          echo ":: BLOCKED: PocketID database has a live file holder" >&2
+          exit 1
+        fi
+        sudo systemctl reset-failed docker-netbird-pocketid.service
+        sudo systemctl start docker-netbird-pocketid.service
+      fi
+      systemctl is-active docker-netbird-pocketid.service
+      healthy=false
+      for _ in $(seq 1 30); do
+        if curl --fail --silent --max-time 5 \
+          https://id.homelab.pastelariadev.com/.well-known/openid-configuration >/dev/null; then
+          healthy=true
+          break
+        fi
+        sleep 1
+      done
+      "$healthy"
+    REMOTE
+    echo ":: PASS: PocketID recovered without database mutation"
+
+# Restore a consistent PocketID SQLite backup into a networkless Orion instance.
+discovery-pocketid-restore-drill:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    sqlite3=$(nix eval --raw .#nixosConfigurations.discovery.pkgs.sqlite.outPath)/bin/sqlite3
+    scan=$(mktemp)
+    trap 'rm -f "$scan"' EXIT
+    ssh-keyscan -p 2222 {{ip_discovery}} >"$scan" 2>/dev/null
+    ssh-keygen -lf "$scan" -E sha256 |
+      grep -Fq 'SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE'
+    hostkeys=$(base64 -w0 "$scan")
+    ssh -p 2222 erik@{{ip_orion}} \
+      "HOSTKEYS=$hostkeys SQLITE3=$sqlite3 DISCOVERY_SQLITE3=$sqlite3 bash -s" <<'REMOTE'
+      set -euo pipefail
+      image=ghcr.io/pocket-id/pocket-id:v2.10.0
+      stamp=$(date +%Y-%m-%d_%H%M%S)
+      evidence="/projects/recovery/discovery-esp/pocketid/$stamp"
+      data="$evidence/data"
+      environment="$evidence/pocketid.env"
+      name="discovery-pocketid-drill-$stamp"
+      known_hosts=$(mktemp)
+      printf '%s' "$HOSTKEYS" | base64 -d >"$known_hosts"
+      options=(-p 2222 -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$known_hosts")
+      sudo install -d -m 0700 -o root -g root "$evidence"
+      sudo install -d -m 0700 -o root -g root "$data"
+      sudo chown 1000:1000 "$data"
+      trap 'rm -f "$known_hosts"; sudo docker rm -f "$name" >/dev/null 2>&1 || true' EXIT
+      ssh -n "${options[@]}" erik@{{ip_discovery}} \
+        "tmp=\$(mktemp /tmp/pocketid.XXXXXX.db); trap 'rm -f \"\$tmp\"' EXIT; $DISCOVERY_SQLITE3 /home/erik/homelab/apps/netbird/pocket-id/pocket-id.db \".backup \$tmp\"; gzip -c \"\$tmp\"" |
+        sudo gzip -dc | sudo tee "$data/pocket-id.db" >/dev/null
+      ssh -n "${options[@]}" erik@{{ip_discovery}} \
+        'sudo cat /run/vault-agent/netbird-pocketid.env' |
+        sudo tee "$environment" >/dev/null
+      sudo chmod 0600 "$environment"
+      sudo chown 1000:1000 "$data/pocket-id.db"
+      test "$(sudo "$SQLITE3" -readonly "$data/pocket-id.db" 'PRAGMA integrity_check')" = ok
+      actor_leases=$(sudo "$SQLITE3" -readonly "$data/pocket-id.db" \
+        "SELECT count(*) FROM kv WHERE key='application_lock'")
+      sudo "$SQLITE3" "$data/pocket-id.db" "DELETE FROM kv WHERE key='application_lock'"
+      test "$(sudo "$SQLITE3" -readonly "$data/pocket-id.db" \
+        "SELECT count(*) FROM kv WHERE key='application_lock'")" = 0
+      view_cleanup=$(sudo "$SQLITE3" -readonly "$data/pocket-id.db" \
+        "SELECT 'DROP VIEW IF EXISTS \"' || replace(name, '\"', '\"\"') || '\";' FROM sqlite_master WHERE type='view' AND name LIKE 'francis_%'")
+      table_cleanup=$(sudo "$SQLITE3" -readonly "$data/pocket-id.db" \
+        "SELECT 'DROP TABLE IF EXISTS \"' || replace(name, '\"', '\"\"') || '\";' FROM sqlite_master WHERE type='table' AND name LIKE 'francis_%'")
+      test -n "$table_cleanup"
+      actor_cleanup="$view_cleanup"$'\n'"$table_cleanup"
+      sudo "$SQLITE3" "$data/pocket-id.db" \
+        "PRAGMA foreign_keys=OFF; BEGIN; $actor_cleanup COMMIT;"
+      actor_tables=$(wc -l <<<"$table_cleanup")
+      sudo docker image inspect "$image" >/dev/null 2>&1 || sudo docker pull "$image"
+      sudo docker run -d --network none --name "$name" \
+        --env-file "$environment" \
+        -e APP_URL=https://id.homelab.pastelariadev.com \
+        -e TRUST_PROXY=true \
+        -v "$data:/app/data" "$image" >/dev/null
+      healthy=false
+      for _ in $(seq 1 60); do
+        if sudo docker exec "$name" /app/pocket-id healthcheck >/dev/null 2>&1; then
+          healthy=true
+          break
+        fi
+        sleep 1
+      done
+      if ! "$healthy"; then
+        sudo docker logs "$name"
+        exit 1
+      fi
+      {
+        printf 'integrity=ok app_locks_removed=%s actor_tables_reset=%s users=%s groups=%s oidc_clients=%s\n' \
+          "$actor_leases" "$actor_tables" \
+          "$(sudo "$SQLITE3" -readonly "$data/pocket-id.db" 'SELECT count(*) FROM users')" \
+          "$(sudo "$SQLITE3" -readonly "$data/pocket-id.db" 'SELECT count(*) FROM user_groups')" \
+          "$(sudo "$SQLITE3" -readonly "$data/pocket-id.db" 'SELECT count(*) FROM oidc_clients')"
+        sudo sha256sum "$data/pocket-id.db"
+      } | sudo tee "$evidence/result.txt"
+      sudo chmod 0600 "$evidence/result.txt"
+    REMOTE
+    echo ":: PASS: PocketID restored and healthy on networkless Orion"
+
+# Start restored NetBird management + PostgreSQL on an Orion-internal network.
+discovery-netbird-management-restore-drill:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    scan=$(mktemp)
+    trap 'rm -f "$scan"' EXIT
+    ssh-keyscan -p 2222 {{ip_discovery}} >"$scan" 2>/dev/null
+    ssh-keygen -lf "$scan" -E sha256 |
+      grep -Fq 'SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE'
+    hostkeys=$(base64 -w0 "$scan")
+    ssh -p 2222 erik@{{ip_orion}} "HOSTKEYS=$hostkeys bash -s" <<'REMOTE'
+      set -euo pipefail
+      postgres_image='postgres:18.4@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a'
+      management_image=netbirdio/management:0.74.3
+      stamp=$(date +%Y-%m-%d_%H%M%S)
+      evidence="/projects/recovery/discovery-esp/netbird/$stamp"
+      config="$evidence/management.json"
+      environment="$evidence/postgres.env"
+      network="discovery-netbird-drill-$stamp"
+      postgres="discovery-netbird-postgres-$stamp"
+      management="discovery-netbird-management-$stamp"
+      known_hosts=$(mktemp)
+      printf '%s' "$HOSTKEYS" | base64 -d >"$known_hosts"
+      options=(-p 2222 -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$known_hosts")
+      dump=$(sudo find /projects/recovery/discovery-esp/postgres -mindepth 2 -maxdepth 2 \
+        -name postgres-all.sql.gz -printf '%T@ %p\n' | sort -nr | head -1 | cut -d' ' -f2-)
+      sudo test -s "$dump"
+      sudo install -d -m 0700 -o root -g root "$evidence"
+      trap 'rm -f "$known_hosts"; sudo docker rm -f "$management" "$postgres" >/dev/null 2>&1 || true; sudo docker network rm "$network" >/dev/null 2>&1 || true' EXIT
+      ssh -n "${options[@]}" erik@{{ip_discovery}} \
+        'sudo cat /run/netbird-management/management.json' |
+        sudo tee "$config" >/dev/null
+      ssh -n "${options[@]}" erik@{{ip_discovery}} \
+        'sudo cat /run/vault-agent/netbird-postgres.env' |
+        sudo tee "$environment" >/dev/null
+      sudo sed -Ei 's#(@)[^/:]+(:[0-9]+)?/#\1postgres:5432/#' "$environment"
+      sudo grep -q '^NETBIRD_STORE_ENGINE_POSTGRES_DSN=' "$environment"
+      sudo chmod 0600 "$config" "$environment"
+      sudo docker image inspect "$postgres_image" >/dev/null 2>&1 ||
+        sudo docker pull "$postgres_image"
+      sudo docker image inspect "$management_image" >/dev/null 2>&1 ||
+        sudo docker pull "$management_image"
+      sudo docker network create --internal "$network" >/dev/null
+      sudo docker run -d --network "$network" --network-alias postgres \
+        --name "$postgres" -e POSTGRES_PASSWORD=drill-only "$postgres_image" >/dev/null
+      ready=false
+      for _ in $(seq 1 60); do
+        if sudo docker exec "$postgres" pg_isready -U postgres >/dev/null 2>&1; then
+          ready=true
+          break
+        fi
+        sleep 1
+      done
+      "$ready"
+      sudo gzip -dc "$dump" |
+        sudo docker exec -i "$postgres" psql -v ON_ERROR_STOP=1 -U postgres postgres >/dev/null
+      sudo docker run -d --network "$network" --name "$management" \
+        --env-file "$environment" \
+        -e NETBIRD_STORE_ENGINE=postgres \
+        -v "$config:/etc/netbird/management.json:ro" \
+        "$management_image" \
+        --port 443 --log-file console --log-level info \
+        --disable-anonymous-metrics=true --dns-domain=netbird.selfhosted >/dev/null
+      sleep 10
+      sudo docker inspect "$management" | jq -e '.[0].State.Running' >/dev/null
+      test -z "$(sudo docker port "$management")"
+      {
+        for table in peers groups users; do
+          count=$(sudo docker exec "$postgres" psql -AtU postgres netbird \
+            -c "SELECT count(*) FROM $table")
+          printf '%s=%s\n' "$table" "$count"
+        done
+        printf 'network=internal published_ports=0 management=running\n'
+        sudo sha256sum "$dump"
+      } | sudo tee "$evidence/result.txt"
+      sudo chmod 0600 "$evidence/result.txt"
+    REMOTE
+    echo ":: PASS: NetBird management read restored PostgreSQL on internal Orion network"
+
+# Copy SWAG state and validate nginx/certificates on networkless Orion.
+discovery-swag-restore-drill:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    openssl=$(nix eval --raw .#nixosConfigurations.orion.pkgs.openssl.outPath)/bin/openssl
+    scan=$(mktemp)
+    trap 'rm -f "$scan"' EXIT
+    ssh-keyscan -p 2222 {{ip_discovery}} >"$scan" 2>/dev/null
+    if ! ssh-keygen -lf "$scan" -E sha256 |
+      grep -Fq 'SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE'; then
+      ssh-keygen -lf "$scan" -E sha256
+      exit 1
+    fi
+    hostkeys=$(base64 -w0 "$scan")
+    ssh -p 2222 erik@{{ip_orion}} "HOSTKEYS=$hostkeys OPENSSL=$openssl bash -s" <<'REMOTE'
+      set -euo pipefail
+      image='lscr.io/linuxserver/swag:5.6.0-ls467@sha256:ce148c3794d2dfcb63eaeed55c516324e800349f8cd57e49ec0eb312fe75f01d'
+      stamp=$(date +%Y-%m-%d_%H%M%S)
+      evidence="/projects/recovery/discovery-esp/swag/$stamp"
+      config="$evidence/config"
+      known_hosts=$(mktemp)
+      printf '%s' "$HOSTKEYS" | base64 -d >"$known_hosts"
+      remote_shell="sudo -H -u erik ssh -p 2222 -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$known_hosts"
+      trap 'rm -f "$known_hosts"' EXIT
+      echo ":: prepare"
+      sudo install -d -m 0700 -o root -g root "$config"
+      echo ":: rsync"
+      set +e
+      sudo rsync -aHAXx --numeric-ids --delete --stats \
+        --rsync-path='sudo rsync' -e "$remote_shell" \
+        erik@{{ip_discovery}}:/home/erik/servarr/machines/discovery/config/swag/ "$config/"
+      status=$?
+      set -e
+      case "$status" in 0|24) ;; *) exit "$status" ;; esac
+      printf 'rsync_status=%s\n' "$status"
+      for route in harbor netbird pocket-id grafana; do
+        printf 'route=%s\n' "$route"
+        sudo test -s "$config/nginx/proxy-confs/$route.subdomain.conf"
+      done
+      mapfile -t fullchains < <(sudo find -L "$config/etc/letsencrypt/live" \
+        -type f -name fullchain.pem -print)
+      printf 'fullchains=%s\n' "${#fullchains[@]}"
+      if test "${#fullchains[@]}" = 0; then
+        sudo find "$config" -maxdepth 6 \( -name fullchain.pem -o -name privkey.pem \) -print
+      fi
+      test "${#fullchains[@]}" -gt 0
+      for fullchain in "${fullchains[@]}"; do
+        privkey="$(dirname "$fullchain")/privkey.pem"
+        sudo test -s "$privkey"
+        sudo "$OPENSSL" x509 -checkend 604800 -noout -in "$fullchain"
+        cert_key=$(sudo "$OPENSSL" x509 -in "$fullchain" -pubkey -noout |
+          "$OPENSSL" pkey -pubin -outform DER | sha256sum | cut -d' ' -f1)
+        private_key=$(sudo "$OPENSSL" pkey -in "$privkey" -pubout -outform DER |
+          sha256sum | cut -d' ' -f1)
+        test "$cert_key" = "$private_key"
+      done
+      sudo docker image inspect "$image" >/dev/null 2>&1 || sudo docker pull "$image"
+      echo ":: nginx -t"
+      sudo docker run --rm --network none --entrypoint /usr/sbin/nginx \
+        -v "$config:/config" "$image" \
+        -t -c /config/nginx/nginx.conf
+      proxy_count=$(sudo find "$config/nginx/proxy-confs" -type f \
+        -name '*.subdomain.conf' | wc -l)
+      manifest=$(sudo find "$config" -xdev -printf '%P\t%y\t%s\t%m\t%U\t%G\n' |
+        LC_ALL=C sort | sha256sum | cut -d' ' -f1)
+      printf 'nginx=valid certificates=%s key_match=true proxy_configs=%s manifest_sha256=%s\n' \
+        "${#fullchains[@]}" "$proxy_count" "$manifest" | sudo tee "$evidence/result.txt"
+      sudo chmod 0600 "$evidence/result.txt"
+    REMOTE
+    echo ":: PASS: copied SWAG config and certificate validate on networkless Orion"
+
+# Read-only Harbor state/identity/capacity gate before copying vault data.
+discovery-harbor-restore-preflight:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source_bytes=$(ssh -p 2222 erik@{{ip_discovery}} 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      state=/home/erik/vault/harbor
+      installer=/home/erik/servarr/machines/discovery/.harbor-installer/harbor
+      test "$(findmnt -nro UUID /home/erik/vault)" = d026033d-158d-49ca-9ff9-dd2d5c8a21dc
+      sudo test -d "$state"
+      test -d "$installer"
+      systemctl is-active --quiet harbor.service
+      bytes=$(sudo du -xsb "$state" | cut -f1)
+      printf 'state_bytes=%s\n' "$bytes" >&2
+      du -sb "$installer" | awk '{print "installer_bytes=" $1}' >&2
+      sudo docker ps -a --format json |
+        jq -r 'select((.Names // "") | test("harbor|registry")) | [.Names, .State, .Image] | @tsv' >&2
+      printf '%s\n' "$bytes"
+    REMOTE
+    )
+    [[ "$source_bytes" =~ ^[0-9]+$ ]]
+    ssh -p 2222 erik@{{ip_orion}} "SOURCE_BYTES=$source_bytes bash -s" <<'REMOTE'
+      set -euo pipefail
+      target=/projects/recovery/discovery-esp/harbor
+      available=$(findmnt -bnro AVAIL -T /projects)
+      required=$((SOURCE_BYTES * 6 / 5))
+      test "$available" -ge "$required"
+      printf 'source_bytes=%s available=%s required=%s target=%s\n' \
+        "$SOURCE_BYTES" "$available" "$required" "$target"
+    REMOTE
+    echo ":: PASS: Harbor vault state identified and Orion has restore capacity"
+
+# Seed Harbor vault state + generated installer onto Orion while Harbor runs.
+discovery-harbor-restore-seed:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just discovery-harbor-restore-preflight
+    scan=$(mktemp)
+    trap 'rm -f "$scan"' EXIT
+    ssh-keyscan -p 2222 {{ip_discovery}} >"$scan" 2>/dev/null
+    ssh-keygen -lf "$scan" -E sha256 |
+      grep -Fq 'SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE'
+    hostkeys=$(base64 -w0 "$scan")
+    ssh -p 2222 erik@{{ip_orion}} "HOSTKEYS=$hostkeys bash -s" <<'REMOTE'
+      set -euo pipefail
+      root=/projects/recovery/discovery-esp/harbor
+      state=$root/state
+      installer=$root/installer
+      known_hosts=$(mktemp)
+      printf '%s' "$HOSTKEYS" | base64 -d >"$known_hosts"
+      remote_shell="sudo -H -u erik ssh -p 2222 -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$known_hosts"
+      trap 'rm -f "$known_hosts"' EXIT
+      sudo test ! -e "$state"
+      sudo test ! -e "$installer"
+      sudo install -d -m 0700 -o root -g root "$state" "$installer"
+      set +e
+      sudo rsync -aHAXx --numeric-ids --delete --stats \
+        --rsync-path='sudo rsync' -e "$remote_shell" \
+        erik@{{ip_discovery}}:/home/erik/vault/harbor/ "$state/"
+      state_status=$?
+      sudo rsync -aHAXx --numeric-ids --delete --stats \
+        --rsync-path='sudo rsync' -e "$remote_shell" \
+        erik@{{ip_discovery}}:/home/erik/servarr/machines/discovery/.harbor-installer/harbor/ "$installer/"
+      installer_status=$?
+      set -e
+      case "$state_status" in 0|24) ;; *) exit "$state_status" ;; esac
+      case "$installer_status" in 0|24) ;; *) exit "$installer_status" ;; esac
+      sudo du -xsb "$state" | awk '{print "state_bytes=" $1}'
+      sudo du -xsb "$installer" | awk '{print "installer_bytes=" $1}'
+      printf 'state_rsync_status=%s installer_rsync_status=%s\n' \
+        "$state_status" "$installer_status"
+    REMOTE
+    echo ":: PASS: online Harbor restore seed complete; stopped final sync required"
+
+# Briefly stop only Harbor, take the final exact delta, then always restart it.
+discovery-harbor-restore-finalize:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    scan=$(mktemp)
+    trap 'rm -f "$scan"' EXIT
+    ssh-keyscan -p 2222 {{ip_discovery}} >"$scan" 2>/dev/null
+    ssh-keygen -lf "$scan" -E sha256 |
+      grep -Fq 'SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE'
+    hostkeys=$(base64 -w0 "$scan")
+    ssh -p 2222 erik@{{ip_orion}} "HOSTKEYS=$hostkeys bash -s" <<'REMOTE'
+      set -euo pipefail
+      state=/projects/recovery/discovery-esp/harbor/state
+      known_hosts=$(mktemp)
+      printf '%s' "$HOSTKEYS" | base64 -d >"$known_hosts"
+      options=(-p 2222 -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$known_hosts")
+      remote_shell="sudo -H -u erik ssh ${options[*]}"
+      sudo test -d "$state"
+      resume() {
+        ssh -n "${options[@]}" erik@{{ip_discovery}} \
+          'sudo systemctl start harbor.service' >/dev/null 2>&1 || true
+        rm -f "$known_hosts"
+      }
+      trap resume EXIT
+      ssh -n "${options[@]}" erik@{{ip_discovery}} '
+        set -euo pipefail
+        test "$(findmnt -nro UUID /home/erik/vault)" = d026033d-158d-49ca-9ff9-dd2d5c8a21dc
+        systemctl is-active --quiet harbor.service
+        sudo systemctl stop harbor.service
+        test "$(systemctl is-active harbor.service 2>/dev/null || true)" = inactive
+      '
+      started=$(date +%s)
+      sudo rsync -aHAXx --numeric-ids --delete --stats \
+        --rsync-path='sudo rsync' -e "$remote_shell" \
+        erik@{{ip_discovery}}:/home/erik/vault/harbor/ "$state/"
+      drift=$(sudo rsync -aHAXxni --numeric-ids --delete \
+        --rsync-path='sudo rsync' -e "$remote_shell" \
+        erik@{{ip_discovery}}:/home/erik/vault/harbor/ "$state/")
+      test -z "$drift" || { printf '%s\n' "$drift" >&2; exit 1; }
+      ssh -n "${options[@]}" erik@{{ip_discovery}} 'sudo systemctl start harbor.service'
+      ssh -n "${options[@]}" erik@{{ip_discovery}} '
+        set -euo pipefail
+        healthy=false
+        for _ in $(seq 1 60); do
+          if curl --fail --silent --max-time 3 http://127.0.0.1:8085/api/v2.0/health |
+            jq -e ".status == \"healthy\"" >/dev/null 2>&1; then
+            healthy=true
+            break
+          fi
+          sleep 1
+        done
+        "$healthy"
+        systemctl is-active harbor.service
+      '
+      trap - EXIT
+      rm -f "$known_hosts"
+      printf 'final_sync_seconds=%s drift=zero\n' "$(( $(date +%s) - started ))"
+    REMOTE
+    echo ":: PASS: Harbor final copy is exact and production API recovered"
+
+# Print only generated Harbor topology needed to design an isolated boot.
+discovery-harbor-restore-inspect:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ssh -p 2222 erik@{{ip_orion}} 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      installer=/projects/recovery/discovery-esp/harbor/installer
+      sudo test -f "$installer/docker-compose.yml"
+      sudo docker compose -f "$installer/docker-compose.yml" config --format json |
+        jq -c '
+          .services | to_entries[] |
+          {
+            service: .key,
+            image: .value.image,
+            mounts: [.value.volumes[]? | {type, source, target}],
+            ports: [.value.ports[]? | {target, published, protocol}],
+            networks: (.value.networks // {})
+          }'
+    REMOTE
+
+# Rebuild copied Harbor state on loopback, then pull, push, and delete a scratch tag.
+discovery-harbor-restore-drill:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ssh -p 2222 erik@{{ip_orion}} 'sudo bash -s' <<'REMOTE'
+      set -euo pipefail
+      root=/projects/recovery/discovery-esp/harbor
+      source_installer=$root/installer
+      installer=$root/drill-installer
+      state=$root/state
+      tag="discovery-esp-drill-$(date +%s)"
+      export COMPOSE_PROJECT_NAME=discovery-harbor-drill
+      cleanup() {
+        test -z "${authfile:-}" || rm -f "$authfile"
+        cd "$installer" 2>/dev/null &&
+          sudo -E docker compose down --remove-orphans >/dev/null 2>&1 || true
+      }
+      trap cleanup EXIT
+      sudo test -d "$state"
+      sudo test -x "$source_installer/prepare"
+      sudo rm -rf "$installer"
+      sudo cp -a "$source_installer" "$installer"
+      sudo chown -R erik:users "$installer"
+      cd "$installer"
+      sed -i \
+        -e 's|^hostname:.*|hostname: harbor-drill.invalid|' \
+        -e 's|^  port: 8085$|  port: 18085|' \
+        -e "s|^data_volume:.*|data_volume: $state|" \
+        -e "s|^    location:.*|    location: $root/log|" \
+        harbor.yml
+      if grep -q '^external_url:' harbor.yml; then
+        sed -i 's|^external_url:.*|external_url: http://127.0.0.1:18085|' harbor.yml
+      fi
+      sudo install -d -m 0700 "$root/log"
+      bash ./prepare
+      awk '
+        /^    logging:$/ { skip=1; next }
+        skip && (/^[^ ]/ || /^  [^ ]/ || /^    [[:alnum:]_-]+:/) { skip=0 }
+        !skip
+      ' docker-compose.yml >docker-compose.yml.tmp
+      mv docker-compose.yml.tmp docker-compose.yml
+      sed -i \
+        -e 's|18085:8080|127.0.0.1:18085:8080|' \
+        docker-compose.yml
+      sudo -E docker compose up -d
+      healthy=false
+      for _ in $(seq 1 120); do
+        if curl --fail --silent --max-time 3 \
+          http://127.0.0.1:18085/api/v2.0/health |
+          jq -e '.status == "healthy"' >/dev/null 2>&1; then
+          healthy=true
+          break
+        fi
+        sleep 1
+      done
+      "$healthy"
+      password=$(sed -n 's/^harbor_admin_password:[[:space:]]*//p' harbor.yml)
+      test -n "$password"
+      auth="admin:$password"
+      image=library/kindle-dash
+      source="docker://127.0.0.1:18085/$image:v0.3.4"
+      target="docker://127.0.0.1:18085/$image:$tag"
+      authfile=$(mktemp)
+      rm -f "$authfile"
+      printf '%s' "$password" |
+        podman login --authfile "$authfile" --tls-verify=false \
+          -u admin --password-stdin 127.0.0.1:18085 >/dev/null
+      source=${source#docker://}
+      target=${target#docker://}
+      podman pull --authfile "$authfile" --tls-verify=false "$source" >/dev/null
+      podman tag "$source" "$target"
+      podman push --authfile "$authfile" --tls-verify=false "$target" >/dev/null
+      podman rmi "$target" >/dev/null
+      podman pull --authfile "$authfile" --tls-verify=false "$target" >/dev/null
+      curl --fail --silent -o /dev/null -u "$auth" \
+        http://127.0.0.1:18085/api/v2.0/system/gc/schedule
+      curl --fail --silent -u "$auth" -X DELETE \
+        "http://127.0.0.1:18085/api/v2.0/projects/library/repositories/kindle-dash/artifacts/$tag"
+      rm -f "$authfile"
+      status=$(sudo -E docker compose ps)
+      printf '%s\n' "$status"
+      ! grep -Fq '0.0.0.0:18085' <<<"$status"
+    REMOTE
+    echo ":: PASS: isolated Harbor restored; auth, pull, push, delete, and GC metadata passed"
+
+# Read-only identity/capacity/tooling gate before cloning the HAOS disk.
+discovery-haos-restore-preflight:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    qemu=$(nix eval --raw .#nixosConfigurations.orion.pkgs.qemu.outPath)
+    source_bytes=$(ssh -p 2222 erik@{{ip_discovery}} 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      printf 'vault_uuid=%s vm_state=%s qemu_img=%s\n' \
+        "$(findmnt -nro UUID /home/erik/vault)" \
+        "$(sudo virsh domstate haos 2>/dev/null || true)" \
+        "$(command -v qemu-img || true)" >&2
+      sudo virsh domblklist haos --details >&2
+      test "$(findmnt -nro UUID /home/erik/vault)" = d026033d-158d-49ca-9ff9-dd2d5c8a21dc
+      test "$(sudo virsh domstate haos)" = running
+      disk=$(sudo virsh domblklist haos --details |
+        awk '$1 == "file" && $2 == "disk" { print $4 }')
+      test -n "$disk"
+      sudo test -f "$disk"
+      bytes=$(sudo stat -c %s "$disk")
+      printf 'disk=%s virtual=%s bytes=%s\n' \
+        "$disk" "$(sudo qemu-img info --force-share --output json "$disk" | jq -r '."virtual-size"')" "$bytes" >&2
+      printf '%s\n' "$bytes"
+    REMOTE
+    )
+    [[ "$source_bytes" =~ ^[0-9]+$ ]]
+    ssh -p 2222 erik@{{ip_orion}} \
+      "SOURCE_BYTES=$source_bytes QEMU_IMG=$qemu/bin/qemu-img QEMU_SYSTEM=$qemu/bin/qemu-system-x86_64 bash -s" <<'REMOTE'
+      set -euo pipefail
+      printf 'qemu_img=%s qemu_system=%s projects_avail=%s\n' \
+        "$([[ -x "$QEMU_IMG" ]] && echo yes || echo no)" \
+        "$([[ -x "$QEMU_SYSTEM" ]] && echo yes || echo no)" \
+        "$(findmnt -bnro AVAIL -T /projects 2>/dev/null || true)" >&2
+      test -x "$QEMU_IMG"
+      test -x "$QEMU_SYSTEM"
+      available=$(findmnt -bnro AVAIL -T /projects)
+      required=$((SOURCE_BYTES * 6 / 5))
+      test "$available" -ge "$required"
+      printf 'source_bytes=%s available=%s required=%s\n' \
+        "$SOURCE_BYTES" "$available" "$required"
+    REMOTE
+    echo ":: PASS: HAOS disk identified and Orion has clone/boot capacity"
+
+# Seed the HAOS QCOW2 onto Orion while the production VM remains online.
+discovery-haos-restore-seed:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just discovery-haos-restore-preflight
+    scan=$(mktemp)
+    trap 'rm -f "$scan"' EXIT
+    ssh-keyscan -p 2222 {{ip_discovery}} >"$scan" 2>/dev/null
+    ssh-keygen -lf "$scan" -E sha256 |
+      grep -Fq 'SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE'
+    hostkeys=$(base64 -w0 "$scan")
+    ssh -p 2222 erik@{{ip_orion}} "HOSTKEYS=$hostkeys bash -s" <<'REMOTE'
+      set -euo pipefail
+      root=/projects/recovery/discovery-esp/haos
+      target=$root/haos_ova-17.1.qcow2
+      known_hosts=$(mktemp)
+      printf '%s' "$HOSTKEYS" | base64 -d >"$known_hosts"
+      remote_shell="sudo -H -u erik ssh -p 2222 -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$known_hosts"
+      trap 'rm -f "$known_hosts"' EXIT
+      sudo test ! -e "$target"
+      sudo install -d -m 0700 -o root -g root "$root"
+      sudo rsync -aHAXS --numeric-ids --stats \
+        --rsync-path='sudo rsync' -e "$remote_shell" \
+        erik@{{ip_discovery}}:/srv/vms/haos_ova-17.1.qcow2 "$target"
+      sudo stat -c 'bytes=%s blocks=%b mode=%a uid=%U gid=%G' "$target"
+    REMOTE
+    echo ":: PASS: online HAOS clone seed complete; stopped final sync required"
+
+# Gracefully stop HAOS, finalize its exact clone, always restart, then check clone.
+discovery-haos-restore-finalize:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    qemu=$(nix eval --raw .#nixosConfigurations.orion.pkgs.qemu.outPath)
+    scan=$(mktemp)
+    trap 'rm -f "$scan"' EXIT
+    ssh-keyscan -p 2222 {{ip_discovery}} >"$scan" 2>/dev/null
+    ssh-keygen -lf "$scan" -E sha256 |
+      grep -Fq 'SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE'
+    hostkeys=$(base64 -w0 "$scan")
+    ssh -p 2222 erik@{{ip_orion}} \
+      "HOSTKEYS=$hostkeys QEMU_IMG=$qemu/bin/qemu-img bash -s" <<'REMOTE'
+      set -euo pipefail
+      target=/projects/recovery/discovery-esp/haos/haos_ova-17.1.qcow2
+      known_hosts=$(mktemp)
+      printf '%s' "$HOSTKEYS" | base64 -d >"$known_hosts"
+      options=(-p 2222 -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$known_hosts")
+      remote_shell="sudo -H -u erik ssh ${options[*]}"
+      printf 'clone=' >&2
+      sudo stat -c 'bytes=%s mode=%a' "$target" >&2 || true
+      printf 'remote_vm_state=' >&2
+      ssh -n "${options[@]}" erik@{{ip_discovery}} \
+        'sudo virsh domstate haos 2>/dev/null || true' >&2
+      sudo test -f "$target"
+      resume() {
+        ssh -n "${options[@]}" erik@{{ip_discovery}} \
+          'sudo virsh start haos >/dev/null 2>&1 || true'
+        rm -f "$known_hosts"
+      }
+      trap resume EXIT
+      ssh -n "${options[@]}" erik@{{ip_discovery}} '
+        set -euo pipefail
+        test "$(findmnt -nro UUID /home/erik/vault)" = d026033d-158d-49ca-9ff9-dd2d5c8a21dc
+        test "$(sudo virsh domstate haos)" = running
+        sudo virsh shutdown haos
+        stopped=false
+        for _ in $(seq 1 300); do
+          if test "$(sudo virsh domstate haos 2>/dev/null || true)" = "shut off"; then
+            stopped=true
+            break
+          fi
+          sleep 1
+        done
+        "$stopped"
+      '
+      started=$(date +%s)
+      sudo rsync -aHAXS --inplace --numeric-ids --stats \
+        --rsync-path='sudo rsync' -e "$remote_shell" \
+        erik@{{ip_discovery}}:/srv/vms/haos_ova-17.1.qcow2 "$target"
+      drift=$(sudo rsync -aHAXSni --inplace --numeric-ids \
+        --rsync-path='sudo rsync' -e "$remote_shell" \
+        erik@{{ip_discovery}}:/srv/vms/haos_ova-17.1.qcow2 "$target")
+      test -z "$drift" || { printf '%s\n' "$drift" >&2; exit 1; }
+      ssh -n "${options[@]}" erik@{{ip_discovery}} 'sudo virsh start haos'
+      ssh -n "${options[@]}" erik@{{ip_discovery}} '
+        set -euo pipefail
+        healthy=false
+        for _ in $(seq 1 180); do
+          if curl --fail --silent --max-time 3 \
+            http://192.168.10.115:8123/ >/dev/null 2>&1; then
+            healthy=true
+            break
+          fi
+          sleep 1
+        done
+        "$healthy"
+        test "$(sudo virsh domstate haos)" = running
+      '
+      trap - EXIT
+      rm -f "$known_hosts"
+      sudo "$QEMU_IMG" check "$target"
+      printf 'final_sync_seconds=%s drift=zero\n' "$(( $(date +%s) - started ))"
+    REMOTE
+    echo ":: PASS: HAOS exact clone is healthy and production VM recovered"
+
+# Read-only completion gate after final sync/restart; never starts or stops HAOS.
+discovery-haos-restore-result:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    qemu=$(nix eval --raw .#nixosConfigurations.orion.pkgs.qemu.outPath)
+    ssh -p 2222 erik@{{ip_orion}} "QEMU_IMG=$qemu/bin/qemu-img bash -s" <<'REMOTE'
+      set -euo pipefail
+      target=/projects/recovery/discovery-esp/haos/haos_ova-17.1.qcow2
+      sudo "$QEMU_IMG" check "$target"
+    REMOTE
+    ssh -p 2222 erik@{{ip_discovery}} 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      test "$(sudo virsh domstate haos)" = running
+      healthy=false
+      for _ in $(seq 1 600); do
+        if curl --fail --silent --max-time 3 \
+          http://192.168.10.115:8123/ >/dev/null 2>&1; then
+          healthy=true
+          break
+        fi
+        sleep 1
+      done
+      "$healthy"
+    REMOTE
+    echo ":: PASS: HAOS clone integrity and production health recovered"
+
+# Boot the copied HAOS disk read-only on Orion with no network device.
+discovery-haos-boot-drill:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    qemu=$(nix eval --raw .#nixosConfigurations.orion.pkgs.qemu.outPath)
+    ssh -p 2222 erik@{{ip_orion}} \
+      "sudo QEMU=$qemu/bin/qemu-system-x86_64 FIRMWARE=$qemu/share/qemu bash -s" <<'REMOTE'
+      set -euo pipefail
+      disk=/projects/recovery/discovery-esp/haos/haos_ova-17.1.qcow2
+      work=$(mktemp -d /projects/recovery/discovery-esp/haos/boot.XXXXXX)
+      pidfile=$work/qemu.pid
+      log=$work/console.log
+      cleanup() {
+        test ! -s "$pidfile" || kill "$(cat "$pidfile")" >/dev/null 2>&1 || true
+      }
+      trap cleanup EXIT
+      test -x "$QEMU"
+      test -f "$FIRMWARE/edk2-x86_64-code.fd"
+      test -f "$FIRMWARE/edk2-i386-vars.fd"
+      test -f "$disk"
+      cp "$FIRMWARE/edk2-i386-vars.fd" "$work/OVMF_VARS.fd"
+      "$QEMU" \
+        -name discovery-haos-restore-drill \
+        -machine pc,accel=kvm \
+        -cpu host -m 4096 -smp 2 \
+        -drive if=pflash,format=raw,readonly=on,file="$FIRMWARE/edk2-x86_64-code.fd" \
+        -drive if=pflash,format=raw,file="$work/OVMF_VARS.fd" \
+        -device virtio-scsi-pci,id=scsi0 \
+        -drive file="$disk",format=qcow2,if=none,id=disk0 \
+        -device scsi-hd,drive=disk0,bus=scsi0.0 \
+        -nic none -snapshot -display none -monitor none \
+        -serial file:"$log" -daemonize -pidfile "$pidfile"
+      booted=false
+      for _ in $(seq 1 300); do
+        if grep -Eq 'Home Assistant Operating System|Welcome to Home Assistant|ha >' "$log"; then
+          booted=true
+          break
+        fi
+        test -s "$pidfile" && kill -0 "$(cat "$pidfile")"
+        sleep 1
+      done
+      "$booted"
+      grep -E 'Home Assistant Operating System|Welcome to Home Assistant|ha >' "$log" | tail -5
+      kill "$(cat "$pidfile")"
+      wait "$(cat "$pidfile")" 2>/dev/null || true
+      trap - EXIT
+      printf 'network=none disk=snapshot boot=passed\n'
+    REMOTE
+    echo ":: PASS: copied HAOS reached console boundary with no network"
+
+# Read-only sample/capacity inventory before encrypted mutable-state backup.
+discovery-home-restore-preflight:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source_bytes=$(ssh -p 2222 erik@{{ip_discovery}} 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      fixed=(
+        /home/erik/.config/sops/age/keys.txt
+        /etc/ssh/ssh_host_ed25519_key
+      )
+      for path in "${fixed[@]}" \
+        /home/erik/servarr \
+        /home/erik/servarr/machines/discovery/config/swag \
+        /home/erik/homelab/apps/netbird/pocket-id; do
+        if sudo test -e "$path"; then
+          printf 'exists=%s\n' "$path" >&2
+        else
+          printf 'missing=%s\n' "$path" >&2
+        fi
+      done
+      for path in "${fixed[@]}"; do sudo test -s "$path"; done
+      for root in \
+        /home/erik/servarr \
+        /home/erik/servarr/machines/discovery/config/swag \
+        /home/erik/homelab/apps/netbird/pocket-id; do
+        sudo test -d "$root"
+        sudo find "$root" -xdev -type f -size +0c -printf '%s %p\n' |
+          sort -nr | sed -n '1p' >&2
+      done
+      sudo find /home/erik/servarr/machines/discovery/config/swag \
+        -type f -name '*.pem' -printf 'pem=%p\n' | sort | tail -10 >&2
+      sudo find /home/erik/Documents -xdev -type f -size +0c \
+        -printf '%s %p\n' | sort -nr | sed -n '1p' >&2
+      sudo find /home/erik -xdev -type f -size +1G \
+        -printf '%s %p\n' | sort -nr | sed -n '1p' >&2
+      bytes=$(sudo du -xsb /home/erik /etc/ssh | awk '{sum += $1} END {print sum}')
+      printf 'source_bytes=%s\n' "$bytes" >&2
+      printf '%s\n' "$bytes"
+    REMOTE
+    )
+    [[ "$source_bytes" =~ ^[0-9]+$ ]]
+    ssh -p 2222 erik@{{ip_kepler}} "SOURCE_BYTES=$source_bytes bash -s" <<'REMOTE'
+      set -euo pipefail
+      available=$(findmnt -bnro AVAIL -T /bulk)
+      test "$available" -ge "$SOURCE_BYTES"
+      printf 'source_bytes=%s available=%s target=/bulk/backups/discovery-esp-home\n' \
+        "$SOURCE_BYTES" "$available"
+    REMOTE
+    echo ":: PASS: mutable-state restore classes exist and Kepler has capacity"
+
+# Encrypt Discovery home/SSH state to Kepler and hash-verify seven restore classes.
+backup-discovery-home-kepler:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just discovery-home-restore-preflight
+    DISCOVERY="{{ip_discovery}}"
+    KEPLER="{{ip_kepler}}"
+    samples=(
+      "home/erik/.config/sops/age/keys.txt"
+      "etc/ssh/ssh_host_ed25519_key"
+      "home/erik/servarr/machines/discovery/.env.sops"
+      "home/erik/servarr/machines/discovery/config/swag/nginx/proxy-confs/harbor.subdomain.conf"
+      "home/erik/servarr/machines/discovery/config/swag/etc/letsencrypt/live/homelab.pastelariadev.com/priv-fullchain-bundle.pem"
+      "home/erik/homelab/apps/netbird/pocket-id/pocket-id.db"
+      "home/erik/servarr/README.md"
+      "home/erik/backup/Documents/erik/ha-agent/kaggle/out-qwen9b/gguf/model.safetensors-00002-of-00004.safetensors"
+    )
+    password_file=$(mktemp)
+    hashes=$(mktemp)
+    restore=$(mktemp -d)
+    cleanup() {
+      rm -f "$password_file" "$hashes"
+      rm -rf "$restore"
+    }
+    trap cleanup EXIT
+    ssh -p 2222 erik@"$DISCOVERY" \
+      'sudo cat /run/secrets/vault_restic_password' >"$password_file"
+    chmod 0600 "$password_file"
+    export RESTIC_PASSWORD_FILE="$password_file"
+    export RESTIC_REPOSITORY="sftp:erik@$KEPLER:/bulk/backups/discovery-esp-home"
+    sftp_cmd="ssh -p 2222 -o BatchMode=yes erik@$KEPLER -s sftp"
+    restic() {
+      nix shell --builders "{{orion_builder}}" --builders-use-substitutes \
+        --max-jobs 0 nixpkgs#restic -c restic -o "sftp.command=$sftp_cmd" "$@"
+    }
+    for sample in "${samples[@]}"; do
+      ssh -p 2222 erik@"$DISCOVERY" \
+        "sudo stat -c 'sample=%n bytes=%s' '/$sample' 2>/dev/null || echo 'missing=/$sample'" >&2
+      ssh -p 2222 erik@"$DISCOVERY" "sudo test -s '/$sample'"
+      ssh -p 2222 erik@"$DISCOVERY" "sudo sha256sum '/$sample'" >>"$hashes"
+    done
+    if ! restic snapshots >/dev/null 2>&1; then restic init; fi
+    ssh -p 2222 erik@"$DISCOVERY" \
+      'sudo tar --one-file-system -C / -cpf - home/erik etc/ssh' |
+      restic backup --stdin --stdin-filename discovery-mutable-state.tar \
+        --tag discovery-esp
+    snapshot=$(restic snapshots --tag discovery-esp --latest 1 --json |
+      jq -r 'max_by(.time).short_id')
+    test -n "$snapshot" -a "$snapshot" != null
+    restic dump "$snapshot" discovery-mutable-state.tar |
+      tar -xpf - -C "$restore" "${samples[@]}"
+    while read -r expected path; do
+      relative=${path#/}
+      actual=$(sha256sum "$restore/$relative" | awk '{print $1}')
+      test "$actual" = "$expected" || {
+        echo ":: BLOCKED: restore mismatch: $relative" >&2
+        exit 1
+      }
+      printf 'verified=%s sha256=%s\n' "$relative" "$actual"
+    done <"$hashes"
+    printf 'snapshot=%s verified_at=%s\n' "$snapshot" "$(date --iso-8601=seconds)"
+    echo ":: PASS: encrypted Discovery mutable-state snapshot and selective restore verified"
+
+# Read-only live AdGuard identity/mount/capacity gate for isolated restore.
+discovery-adguard-restore-preflight:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source_bytes=$(ssh -p 2222 erik@{{ip_discovery}} 'bash -s' <<'REMOTE'
+      set -euo pipefail
+      expected='adguard/adguardhome:v0.108.0-b.83@sha256:8399ec9bdcb76d5ef4f217ed2d0272dc9f3fb283eb2613744610988232d91927'
+      inspect=$(sudo docker inspect adguard)
+      jq -c '.[0] | {
+        status: .State.Status,
+        image: .Config.Image,
+        mounts: [.Mounts[] | {type: .Type, name: .Name, source: .Source, destination: .Destination}]
+      }' <<<"$inspect" >&2
+      test "$(jq -r '.[0].State.Status' <<<"$inspect")" = running
+      test "$(jq -r '.[0].Config.Image' <<<"$inspect")" = "$expected"
+      work=$(jq -r '.[0].Mounts[] | select(.Destination == "/opt/adguardhome/work") | .Source' <<<"$inspect")
+      config=$(jq -r '.[0].Mounts[] | select(.Destination == "/opt/adguardhome/conf") | .Source' <<<"$inspect")
+      sudo test -d "$work"
+      sudo test -d "$config"
+      work_bytes=$(sudo du -xsb "$work" | cut -f1)
+      config_bytes=$(sudo du -xsb "$config" | cut -f1)
+      printf 'work=%s bytes=%s config=%s bytes=%s\n' \
+        "$work" "$work_bytes" "$config" "$config_bytes" >&2
+      jq -c '.[0] | {
+        image: .Config.Image,
+        mounts: [.Mounts[] | {type: .Type, source: .Source, destination: .Destination}],
+        ports: .NetworkSettings.Ports
+      }' <<<"$inspect" >&2
+      printf '%s\n' "$((work_bytes + config_bytes))"
+    REMOTE
+    )
+    [[ "$source_bytes" =~ ^[0-9]+$ ]]
+    ssh -p 2222 erik@{{ip_orion}} "SOURCE_BYTES=$source_bytes bash -s" <<'REMOTE'
+      set -euo pipefail
+      available=$(findmnt -bnro AVAIL -T /projects)
+      required=$((SOURCE_BYTES * 2))
+      test "$available" -ge "$required"
+      printf 'source_bytes=%s available=%s required=%s\n' \
+        "$SOURCE_BYTES" "$available" "$required"
+    REMOTE
+    echo ":: PASS: live AdGuard state identified and Orion has restore capacity"
+
+# Seed live AdGuard volume/config state onto Orion; stopped final sync follows.
+discovery-adguard-restore-seed:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just discovery-adguard-restore-preflight
+    scan=$(mktemp)
+    trap 'rm -f "$scan"' EXIT
+    ssh-keyscan -p 2222 {{ip_discovery}} >"$scan" 2>/dev/null
+    ssh-keygen -lf "$scan" -E sha256 |
+      grep -Fq 'SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE'
+    hostkeys=$(base64 -w0 "$scan")
+    ssh -p 2222 erik@{{ip_orion}} "sudo HOSTKEYS=$hostkeys bash -s" <<'REMOTE'
+      set -euo pipefail
+      root=/projects/recovery/discovery-esp/adguard
+      known_hosts=$(mktemp)
+      printf '%s' "$HOSTKEYS" | base64 -d >"$known_hosts"
+      chmod 0644 "$known_hosts"
+      remote_shell="sudo -H -u erik ssh -p 2222 -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$known_hosts"
+      trap 'rm -f "$known_hosts"' EXIT
+      install -d -m 0700 "$root/work" "$root/conf"
+      rsync -aHAXx --numeric-ids --delete --stats \
+        --rsync-path='sudo rsync' -e "$remote_shell" \
+        erik@{{ip_discovery}}:/var/lib/docker/volumes/discovery-adguard-work/_data/ "$root/work/"
+      rsync -aHAXx --numeric-ids --delete --stats \
+        --rsync-path='sudo rsync' -e "$remote_shell" \
+        erik@{{ip_discovery}}:/home/erik/servarr/machines/discovery/runtime/adguard/ "$root/conf/"
+      du -xsb "$root/work" "$root/conf"
+    REMOTE
+    echo ":: PASS: online AdGuard restore seed complete; stopped final sync required"
+
+# Stop only AdGuard and its exporter for the final delta, then restore both.
+discovery-adguard-restore-finalize:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    discovery={{ip_discovery}}
+    kepler={{ip_kepler}}
+    evidence=.gsd/evidence/p3-dns/runs/20260715T235959Z-d5cf3b5979d8/result.json
+    jq -e '.status == "passed"' "$evidence" >/dev/null
+    for transport in +notcp +tcp; do
+      test "$(dig "$transport" +short +time=3 +tries=1 @"$kepler" \
+        discovery.homelab.pastelariadev.com A)" = "$discovery"
+      test -n "$(dig "$transport" +short +time=3 +tries=1 @"$kepler" example.com A)"
+    done
+    inspect=$(ssh -p 2222 erik@"$discovery" \
+      'sudo docker inspect adguard adguard-exporter')
+    adguard_id=$(jq -r '.[] | select(.Name == "/adguard") | .Id' <<<"$inspect")
+    exporter_id=$(jq -r '.[] | select(.Name == "/adguard-exporter") | .Id' <<<"$inspect")
+    [[ "$adguard_id" =~ ^[0-9a-f]{64}$ && "$exporter_id" =~ ^[0-9a-f]{64}$ ]]
+    test "$(jq -r '[.[].State.Running] | all' <<<"$inspect")" = true
+    scan=$(mktemp)
+    trap 'rm -f "$scan"' EXIT
+    ssh-keyscan -p 2222 "$discovery" >"$scan" 2>/dev/null
+    ssh-keygen -lf "$scan" -E sha256 |
+      grep -Fq 'SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE'
+    hostkeys=$(base64 -w0 "$scan")
+    stopped=1
+    restart() {
+      if test "$stopped" = 1; then
+        ssh -p 2222 erik@"$discovery" \
+          sudo docker start "$adguard_id" "$exporter_id" >/dev/null
+        stopped=0
+      fi
+    }
+    trap restart EXIT INT TERM
+    started=$(date +%s)
+    ssh -p 2222 erik@"$discovery" \
+      sudo docker stop --time 120 "$exporter_id" "$adguard_id" >/dev/null
+    ssh -p 2222 erik@{{ip_orion}} "sudo HOSTKEYS=$hostkeys bash -s" <<'REMOTE'
+      set -euo pipefail
+      root=/projects/recovery/discovery-esp/adguard
+      test -d "$root/work" -a -d "$root/conf"
+      known_hosts=$(mktemp)
+      printf '%s' "$HOSTKEYS" | base64 -d >"$known_hosts"
+      chmod 0644 "$known_hosts"
+      trap 'rm -f "$known_hosts"' EXIT
+      remote_shell="sudo -H -u erik ssh -p 2222 -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$known_hosts"
+      sync() {
+        rsync -aHAXx --numeric-ids --delete "$@" \
+          --rsync-path='sudo rsync' -e "$remote_shell"
+      }
+      sync erik@{{ip_discovery}}:/var/lib/docker/volumes/discovery-adguard-work/_data/ "$root/work/"
+      sync erik@{{ip_discovery}}:/home/erik/servarr/machines/discovery/runtime/adguard/ "$root/conf/"
+      work_drift=$(sync --dry-run --itemize-changes \
+        erik@{{ip_discovery}}:/var/lib/docker/volumes/discovery-adguard-work/_data/ "$root/work/")
+      conf_drift=$(sync --dry-run --itemize-changes \
+        erik@{{ip_discovery}}:/home/erik/servarr/machines/discovery/runtime/adguard/ "$root/conf/")
+      test -z "$work_drift$conf_drift"
+      du -xsb "$root/work" "$root/conf"
+    REMOTE
+    restart
+    trap - EXIT INT TERM
+    dns_ready=false
+    for _ in $(seq 1 60); do
+      running=$(ssh -p 2222 erik@"$discovery" \
+        "sudo docker inspect '$adguard_id' '$exporter_id'" |
+        jq -r '[.[].State.Running] | all')
+      if test "$running" = true; then
+        dns_ready=true
+        for transport in +notcp +tcp; do
+          test "$(dig "$transport" +short +time=3 +tries=1 @"$discovery" \
+            discovery.homelab.pastelariadev.com A)" = "$discovery" ||
+            dns_ready=false
+          test -n "$(dig "$transport" +short +time=3 +tries=1 \
+            @"$discovery" example.com A)" ||
+            dns_ready=false
+        done
+        test "$dns_ready" = true && break
+      fi
+      sleep 1
+    done
+    test "$dns_ready" = true
+    echo ":: PASS: stopped AdGuard final sync complete; downtime=$(( $(date +%s) - started ))s"
+
+# Boot a disposable copy of AdGuard on Orion loopback and prove DNS behavior.
+discovery-adguard-restore-drill:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ssh -p 2222 erik@{{ip_orion}} 'sudo bash -s' <<'REMOTE'
+      set -euo pipefail
+      image='adguard/adguardhome:v0.108.0-b.83@sha256:8399ec9bdcb76d5ef4f217ed2d0272dc9f3fb283eb2613744610988232d91927'
+      root=/projects/recovery/discovery-esp/adguard
+      source_work=/projects/recovery/discovery-esp/adguard/work
+      source_conf=/projects/recovery/discovery-esp/adguard/conf
+      run=$root/runs/$(date -u +%Y%m%dT%H%M%SZ)
+      work=$run/work
+      conf=$run/conf
+      name=discovery-adguard-restore-drill
+      command -v dig >/dev/null
+      test -d "$source_work" -a -d "$source_conf"
+      ! docker inspect "$name" >/dev/null 2>&1
+      ! ss -H -lntu | grep -Eq '127\.0\.0\.1:(15353|18090)[[:space:]]'
+      install -d -m 0700 "$work" "$conf"
+      cp -a --reflink=auto "$source_work/." "$work/"
+      cp -a --reflink=auto "$source_conf/." "$conf/"
+      docker image inspect "$image" >/dev/null 2>&1 || docker pull "$image"
+      created=false
+      cleanup() {
+        if "$created"; then
+          docker stop --time 30 "$name" >/dev/null 2>&1 || true
+        fi
+      }
+      trap cleanup EXIT INT TERM
+      docker run --detach --rm --name "$name" \
+        -p 127.0.0.1:15353:53/tcp \
+        -p 127.0.0.1:15353:53/udp \
+        -p 127.0.0.1:18090:80/tcp \
+        -v "$work:/opt/adguardhome/work" \
+        -v "$conf:/opt/adguardhome/conf" \
+        "$image" >/dev/null
+      created=true
+      dns_ready=false
+      for _ in $(seq 1 60); do
+        if test "$(dig +notcp +short +time=2 +tries=1 -p 15353 \
+          @127.0.0.1 restore-drill.homelab.pastelariadev.com A)" = \
+          192.168.10.210; then
+          dns_ready=true
+          break
+        fi
+        sleep 1
+      done
+      test "$dns_ready" = true
+      for transport in +notcp +tcp; do
+        test "$(dig "$transport" +short +time=3 +tries=1 -p 15353 \
+          @127.0.0.1 restore-drill.homelab.pastelariadev.com A)" = \
+          192.168.10.210
+        test -n "$(dig "$transport" +short +time=3 +tries=1 -p 15353 \
+          @127.0.0.1 example.com A)"
+        test "$(dig "$transport" +short +time=3 +tries=1 -p 15353 \
+          @127.0.0.1 restore-drill.doubleclick.net A)" = 0.0.0.0
+        dig "$transport" +dnssec +time=3 +tries=1 -p 15353 \
+          @127.0.0.1 cloudflare.com A |
+          grep -Eq 'flags:.* ad[;[:space:]]'
+      done
+      curl --fail --silent --show-error --max-time 3 \
+        -o /dev/null http://127.0.0.1:18090/
+      docker inspect "$name" |
+        jq -c '.[0] | {
+          image: .Image,
+          running: .State.Running,
+          ports: .NetworkSettings.Ports,
+          mounts: [.Mounts[] | {source: .Source, destination: .Destination}]
+        }' | tee "$run/result.json"
+      test "$(jq -r .running "$run/result.json")" = true
+      echo ":: PASS: isolated AdGuard restore resolves fleet/external/filter/DNSSEC over UDP+TCP"
+    REMOTE
 
 # Maintenance-window finalization. This recipe never stops Docker itself: the
 # caller must quiesce dependent writers in the reviewed order first. It refuses

--- a/justfile
+++ b/justfile
@@ -3013,9 +3013,13 @@ backup-discovery-openbao-d4:
       )
       for unit in "${units[@]}"; do
         sudo systemctl start "$unit"
-        sudo systemctl show "$unit" \
-          --property=Id,ExecMainStatus,ActiveEnterTimestamp --value |
-          paste -sd ' ' -
+        snapshot=$(sudo journalctl -u "$unit" -n 200 --no-pager -o cat |
+          sed -n \
+            -e 's/.*snapshot \([0-9a-f]\{8,\}\) saved.*/\1/p' \
+            -e 's/.*"snapshot_id":"\([0-9a-f]\{8,\}\)".*/\1/p' |
+          tail -1)
+        test -n "$snapshot"
+        printf 'unit=%s snapshot=%s\n' "$unit" "$snapshot"
       done
       sudo sha256sum /var/lib/vault-snapshots/openbao.snap
       sudo systemctl start openbao-restore-drill.service

--- a/justfile
+++ b/justfile
@@ -6312,9 +6312,10 @@ discovery-docker-mirror-finalize:
         echo ":: BLOCKED: Docker must already be inactive" >&2
         exit 1
       }
-      test "$(readlink -f /dev/disk/by-id/ata-KINGSTON_SA400S37480G_AA000000000000000105)" = /dev/sda
-      test "$(readlink -f /dev/disk/by-id/ata-KINGSTON_SA400S37480G_AA000000000000000098)" = /dev/sdc
-      test "$(readlink -f /dev/disk/by-id/ata-ST4000DM004-2CV104_ZTT25R4M)" = /dev/sdb
+      primary_root=$(readlink -f /dev/disk/by-id/ata-KINGSTON_SA400S37480G_AA000000000000000105-part2)
+      vault_part=$(readlink -f /dev/disk/by-id/ata-ST4000DM004-2CV104_ZTT25R4M-part1)
+      test "$(findmnt -nro SOURCE -T "$source" | sed "s/\\[.*//")" = "$primary_root"
+      test "$(findmnt -nro SOURCE -T "$destination")" = "$vault_part"
       test "$(findmnt -nro UUID /home/erik/vault)" = d026033d-158d-49ca-9ff9-dd2d5c8a21dc
       test -d "$destination"
       sudo rsync -aHAXx --numeric-ids --delete "$source/" "$destination/"

--- a/modules/hosts/discovery/hermes-wiki.nix
+++ b/modules/hosts/discovery/hermes-wiki.nix
@@ -98,6 +98,8 @@ _: {
         RemainAfterExit = true;
         Restart = "on-failure";
         RestartSec = "15s";
+        StateDirectory = "hermes-wiki-ssh";
+        StateDirectoryMode = "0700";
         ExecStartPre = pkgs.writeShellScript "wait-for-hermes-wiki-key" ''
           for _ in $(seq 1 100); do
             [ -s ${keyPath} ] && [ -r ${keyPath} ] && exit 0
@@ -108,11 +110,15 @@ _: {
       };
       script = ''
         set -euo pipefail
-        export GIT_SSH_COMMAND="ssh -i ${keyPath} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=${wikiDir}/.known_hosts"
+        export GIT_SSH_COMMAND="ssh -i ${keyPath} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/var/lib/hermes-wiki-ssh/known_hosts"
         if [ ! -d ${wikiDir}/.git ]; then
           git clone --branch hermes git@github.com:ErikBPF/vault.git ${wikiDir}
         else
           git -C ${wikiDir} fetch origin hermes
+          if [ "$(git -C ${wikiDir} status --porcelain -- .known_hosts)" = "?? .known_hosts" ]; then
+            test ! -e /var/lib/hermes-wiki-ssh/known_hosts.pre-worktree
+            mv ${wikiDir}/.known_hosts /var/lib/hermes-wiki-ssh/known_hosts.pre-worktree
+          fi
           git -C ${wikiDir} checkout hermes
           git -C ${wikiDir} reset --hard origin/hermes
         fi

--- a/modules/hosts/discovery/telstar-capture.nix
+++ b/modules/hosts/discovery/telstar-capture.nix
@@ -38,7 +38,7 @@ _: {
         Type = "simple";
         User = user;
         Group = "users";
-        WorkingDirectory = "${home}/homelab-iac";
+        WorkingDirectory = home;
         Restart = "on-failure";
         RestartSec = "300";
       };
@@ -47,6 +47,11 @@ _: {
       script = ''
         set -uo pipefail
         export PATH="/run/current-system/sw/bin:${home}/.nix-profile/bin:$PATH"
+        if ! test -d "${home}/homelab-iac/.git"; then
+          test ! -e "${home}/homelab-iac"
+          ${pkgs.git}/bin/git clone --branch main --single-branch \
+            git@github_erikbpf:ErikBPF/homelab-iac.git "${home}/homelab-iac"
+        fi
         cd "${home}/homelab-iac"
         ${pkgs.git}/bin/git pull --ff-only 2>/dev/null || true
         exec ${pkgs.bash}/bin/bash oracle/bin/telstar-get-retry.sh

--- a/tests/discovery-esp-scratch-restore/test_recipe.py
+++ b/tests/discovery-esp-scratch-restore/test_recipe.py
@@ -52,6 +52,20 @@ def test_openbao_d4_backup_refreshes_every_existing_tier():
     assert recipe.index(units[0]) < recipe.index(units[1]) < recipe.index(units[2])
 
 
+def test_identity_backup_covers_tailscale_ssh_and_sops():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("backup-discovery-identity-kepler:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "var/lib/tailscale/tailscaled.state" in recipe
+    assert "etc/ssh/ssh_host_ed25519_key" in recipe
+    assert "home/erik/.config/sops/age/keys.txt" in recipe
+    assert "--tag discovery-esp-identity" in recipe
+    assert "restic dump" in recipe
+    assert "sha256sum" in recipe
+
+
 def test_scratch_restore_preflight_is_read_only_and_targets_orion_projects():
     justfile = (Path(__file__).parents[2] / "justfile").read_text()
     recipe = justfile.split("discovery-docker-scratch-preflight:", 1)[1].split(

--- a/tests/discovery-esp-scratch-restore/test_recipe.py
+++ b/tests/discovery-esp-scratch-restore/test_recipe.py
@@ -66,6 +66,238 @@ def test_identity_backup_covers_tailscale_ssh_and_sops():
     assert "sha256sum" in recipe
 
 
+def test_identity_restore_is_pinned_and_verified_before_service_restart():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("restore-discovery-identity-kepler:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "868abf42" in recipe
+    assert "c6a64318c4b5685b513056d22be3d91c25ae810d6d793c7a9fe400a22ff97c93" in recipe
+    assert "SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE" in recipe
+    assert "restic dump" in recipe
+    assert "systemctl stop tailscaled-autoconnect.service tailscaled.service" in recipe
+    assert recipe.index("sha256sum") < recipe.index("systemctl restart sshd.service")
+    assert "tailscale status --json" in recipe
+
+
+def test_postinstall_storage_check_binds_raid_esp_and_vault():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("verify-discovery-postinstall-storage:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "ata-KINGSTON_SA400S37480G_AA000000000000000105-part1" in recipe
+    assert "ata-KINGSTON_SA400S37480G_AA000000000000000098-part1" in recipe
+    assert "d026033d-158d-49ca-9ff9-dd2d5c8a21dc" in recipe
+    assert "Data,RAID1:" in recipe
+    assert "Metadata,RAID1:" in recipe
+    assert "for mount in /boot /home/erik/vault" in recipe
+
+
+def test_home_restore_is_pinned_quiesced_and_runs_home_manager():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("restore-discovery-home-kepler:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "6943b508" in recipe
+    assert "discovery-mutable-state.tar" in recipe
+    assert "d026033d-158d-49ca-9ff9-dd2d5c8a21dc" in recipe
+    assert "systemctl stop haos-vm.service docker.service docker.socket" in recipe
+    assert "systemctl is-active docker.service" in recipe
+    assert "restic dump" in recipe
+    assert "home-manager-erik.service" in recipe
+    assert "SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE" in recipe
+
+
+def test_restore_quiesce_runtime_masks_stateful_substrates():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("quiesce-discovery-restore:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "systemctl mask --runtime --now" in recipe
+    for unit in [
+        "docker.service",
+        "docker.socket",
+        "libvirtd.service",
+        "haos-vm.service",
+        "openbao.service",
+        "vault-agent.service",
+    ]:
+        assert unit in recipe
+    assert 'systemctl stop "${units[@]}"' in recipe
+
+
+def test_openbao_restore_pins_snapshot_hash_and_verifies_metadata():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("restore-discovery-openbao:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "315ed0ea" in recipe
+    assert "8407ae773697c8511a6d2f2a24f0152dd547a91e7115148c8ecebea4f989ba29" in recipe
+    assert "operator init" in recipe
+    assert "operator raft snapshot restore -force" in recipe
+    assert "/run/secrets/vault_unseal_key" in recipe
+    assert "secret/shared/discord" in recipe
+    assert "systemctl start vault-agent.service" in recipe
+    assert "rm -rf" not in recipe
+    assert "pkgs.restic.outPath" in recipe
+    assert "journalctl -u openbao.service" in recipe
+    assert "ip link add name br-openbao type bridge" in recipe
+    assert "172.31.82.1/29" in recipe
+    assert 'chown -R erik:users "$work"' in recipe
+
+
+def test_openbao_restore_resumes_after_snapshot_import_without_reading_root_secrets_as_erik():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("restore-discovery-openbao:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert 'initialized=$(curl -fsS -m 10 http://127.0.0.1:8200/v1/sys/seal-status' in recipe
+    assert 'if test "$initialized" = false; then' in recipe
+    assert 'sealed=$(curl -fsS -m 10 http://127.0.0.1:8200/v1/sys/seal-status' in recipe
+    assert 'if test "$sealed" = true; then' in recipe
+    assert "unseal_key=$(sudo cat /run/secrets/vault_unseal_key)" in recipe
+    assert "role_id=$(sudo cat /run/secrets/vault_agent_role_id)" in recipe
+    assert "secret_id=$(sudo cat /run/secrets/vault_agent_secret_id)" in recipe
+    assert "--rawfile key /run/secrets/vault_unseal_key" not in recipe
+    assert "--rawfile role_id /run/secrets/vault_agent_role_id" not in recipe
+    for stage in ["seal-status", "approle-login", "kv-proof", "vault-agent"]:
+        assert f"stage={stage}" in recipe
+    assert "for _ in $(seq 1 100); do" in recipe
+    assert 'sudo test -s "$path" && break' in recipe
+
+
+def test_openbao_throwaway_reset_is_guarded_recoverable_and_non_deleting():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("quarantine-discovery-openbao-throwaway:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "du -sb /var/lib/private/openbao" in recipe
+    assert "67108864" in recipe
+    assert "mv /var/lib/private/openbao" in recipe
+    assert "openbao-d5-throwaway" in recipe
+    assert "rm " not in recipe
+
+
+def test_docker_restore_retains_fresh_root_and_proves_exact_cold_mirror():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("restore-discovery-docker:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "d026033d-158d-49ca-9ff9-dd2d5c8a21dc" in recipe
+    assert "discovery-docker-root.final" in recipe
+    assert ".gsd/evidence/discovery-esp/manifest.json" in recipe
+    assert "a654304de8d8a29b1986b8ba9f2b3c19a87d58b58768b60c766d4e621ead42b5" in recipe
+    assert 'scratch_restore == "passed"' in recipe
+    assert "docker-d5-fresh" in recipe
+    assert "1073741824" in recipe
+    assert "10737418240" in recipe
+    assert "config.v2.json" in recipe
+    assert 'sudo mv "$destination" "$retained"' in recipe
+    assert "systemctl mask --runtime --now" in recipe
+    assert 'systemctl mask --runtime --now "${docker_units[@]}" || true' in recipe
+    assert "docker-recover.timer" in recipe
+    assert 'systemctl stop "${docker_units[@]}"' in recipe
+    assert "ConditionPathExists=/run/discovery-docker-restore-start-allowed" in recipe
+    assert "systemctl daemon-reload" in recipe
+    assert 'test "$(systemctl is-active docker.service' in recipe
+    assert "discovery-docker-restore-hold" in recipe
+    assert "sudo rsync -aHAXx --numeric-ids --delete --stats" in recipe
+    assert "sudo rsync -aHAXxni --numeric-ids --delete" in recipe
+    assert 'test -z "$drift"' in recipe
+    assert 'test "$source_manifest" = "$expected_manifest"' in recipe
+    assert 'test "$destination_manifest" = "$expected_manifest"' in recipe
+    assert recipe.count("! -type d -printf") == 2
+    assert "systemctl unmask --runtime docker.service docker.socket" in recipe
+    assert "systemctl start docker.service" in recipe
+    assert "systemctl start docker.service || true" in recipe
+    assert "for _ in $(seq 1 300); do" in recipe
+    assert "systemctl is-active --quiet docker.service && break" in recipe
+    assert "systemctl status docker.service docker.socket" in recipe
+    assert "journalctl -u docker.service" in recipe
+    assert "DockerRootDir" in recipe
+    assert "rm -rf" not in recipe
+    for stage in ["preflight", "retain", "rsync", "manifest", "start"]:
+        assert f"stage={stage}" in recipe
+    assert "vault_uuid=%s marker=%s source=%s docker=%s socket=%s" in recipe
+
+
+def test_postrestore_resume_starts_declarative_owners_and_proves_harbor_haos():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("resume-discovery-postrestore-substrates:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    for unit in [
+        "docker-recover.timer",
+        "openbao-unseal.timer",
+        "libvirtd.service",
+        "haos-vm.service",
+        "harbor.service",
+    ]:
+        assert unit in recipe
+    assert "systemctl unmask --runtime" in recipe
+    assert "systemctl start docker-recover.timer openbao-unseal.timer" in recipe
+    assert "systemctl restart harbor.service" in recipe
+    assert "systemctl start haos-vm.service" in recipe
+    assert "http://127.0.0.1:8085/api/v2.0/health" in recipe
+    assert 'virsh domstate haos | grep -Fx running' in recipe
+    assert "rm " not in recipe
+
+
+def test_final_gate_checks_openbao_unseal_oneshot_via_timer_and_result():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("verify-discovery-esp:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "openbao-unseal.timer" in recipe
+    assert "systemctl show -p Result --value openbao-unseal.service" in recipe
+    assert "openbao openbao-unseal vault-agent" not in recipe
+    assert "@{{ip_discovery}}" in recipe
+    assert "@127.0.0.1" not in recipe
+    for stage in ["openbao", "dns", "grafana", "haos", "failed-units"]:
+        assert f"stage={stage}" in recipe
+
+
+def test_netbird_resume_renders_config_before_restarting_all_controlplane_units():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("resume-discovery-netbird:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "systemctl restart netbird-management-config.service" in recipe
+    for unit in [
+        "docker-netbird-pocketid.service",
+        "docker-netbird-management.service",
+        "docker-netbird-signal.service",
+        "docker-netbird-dashboard.service",
+        "docker-netbird-relay.service",
+    ]:
+        assert unit in recipe
+    assert ".well-known/openid-configuration" in recipe
+    assert "rm " not in recipe
+
+
+def test_kindle_mirror_passes_pinned_skopeo_and_cosign_path_to_remote_script():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("mirror-kindle version digest:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "pkgs.skopeo.outPath" in recipe
+    assert "pkgs.cosign.outPath" in recipe
+    assert "TOOLS_PATH=" in recipe
+    assert 'export PATH="$TOOLS_PATH:$PATH"' in recipe
+
+
 def test_scratch_restore_preflight_is_read_only_and_targets_orion_projects():
     justfile = (Path(__file__).parents[2] / "justfile").read_text()
     recipe = justfile.split("discovery-docker-scratch-preflight:", 1)[1].split(
@@ -534,3 +766,87 @@ def test_adguard_drill_uses_copied_state_and_loopback_dns_only():
     assert "--network host" not in recipe
     assert "192.168.10.210:53" not in recipe
     assert "docker volume" not in recipe
+
+
+def test_discovery_gpu_diagnostic_is_read_only_and_boot_scoped():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("diagnose-discovery-gpu:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "lspci -nnk" in recipe
+    assert "nvidia-smi" in recipe
+    assert "lsmod" in recipe
+    assert "/dev/nvidia" in recipe
+    assert "journalctl -b -k" in recipe
+    assert "nvidia-persistenced.service" in recipe
+    assert "nvidia-container-toolkit-cdi-generator.service" in recipe
+    assert "pkgs.pciutils.outPath" in recipe
+    assert "TOOLS_PATH=" in recipe
+    assert "systemctl start" not in recipe
+    assert "systemctl restart" not in recipe
+    assert "systemctl reset-failed" not in recipe
+
+
+def test_telstar_capture_bootstraps_its_mutable_iac_clone():
+    module = (
+        Path(__file__).parents[2]
+        / "modules/hosts/discovery/telstar-capture.nix"
+    ).read_text()
+
+    assert 'WorkingDirectory = home;' in module
+    assert 'test -d "${home}/homelab-iac/.git"' in module
+    assert "${pkgs.git}/bin/git clone" in module
+    assert "git@github_erikbpf:ErikBPF/homelab-iac.git" in module
+    assert 'cd "${home}/homelab-iac"' in module
+
+
+def test_telstar_pause_stops_only_the_retry_unit():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("pause-discovery-telstar:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "systemctl stop telstar-capture.service" in recipe
+    assert "systemctl reset-failed telstar-capture.service" in recipe
+    assert "systemctl disable" not in recipe
+    assert "rm " not in recipe
+
+
+def test_hermes_wiki_diagnostic_is_read_only():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("diagnose-hermes-wiki:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "systemctl status hermes-wiki-clone.service" in recipe
+    assert "journalctl -u hermes-wiki-clone.service" in recipe
+    assert "systemctl start" not in recipe
+    assert "systemctl reset-failed" not in recipe
+
+
+def test_hermes_wiki_keeps_host_keys_outside_the_checkout():
+    module = (
+        Path(__file__).parents[2]
+        / "modules/hosts/discovery/hermes-wiki.nix"
+    ).read_text()
+
+    assert 'StateDirectory = "hermes-wiki-ssh";' in module
+    assert "UserKnownHostsFile=/var/lib/hermes-wiki-ssh/known_hosts" in module
+    host_git = module.split('export GIT_SSH_COMMAND=', 1)[1].split("\n", 1)[0]
+    assert "${wikiDir}/.known_hosts" not in host_git
+
+
+def test_telstar_state_inventory_is_value_free_and_read_only():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-telstar-state-inventory:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "tofu-state-export/oracle/compute-telstar/terraform.tfstate" in recipe
+    assert "tofu-state-backup/oracle/compute-telstar/terraform.tfstate" in recipe
+    assert "stat -c" in recipe
+    assert "sha256sum" in recipe
+    assert "cat " not in recipe
+    assert "cp " not in recipe
+    assert "rm " not in recipe

--- a/tests/discovery-esp-scratch-restore/test_recipe.py
+++ b/tests/discovery-esp-scratch-restore/test_recipe.py
@@ -47,6 +47,8 @@ def test_openbao_d4_backup_refreshes_every_existing_tier():
         assert unit in recipe
     assert "openbao-restore-drill.service" in recipe
     assert "sha256sum /var/lib/vault-snapshots/openbao.snap" in recipe
+    assert "journalctl -u" in recipe
+    assert "snapshot=" in recipe
     assert recipe.index(units[0]) < recipe.index(units[1]) < recipe.index(units[2])
 
 

--- a/tests/discovery-esp-scratch-restore/test_recipe.py
+++ b/tests/discovery-esp-scratch-restore/test_recipe.py
@@ -31,6 +31,25 @@ def test_docker_finalize_does_not_pin_volatile_device_names():
     assert "/dev/sdc" not in recipe
 
 
+def test_openbao_d4_backup_refreshes_every_existing_tier():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("backup-discovery-openbao-d4:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    units = [
+        "restic-backups-vault.service",
+        "restic-backups-vault-offsite.service",
+        "restic-backups-vault-rest.service",
+        "restic-backups-vault-b2.service",
+    ]
+    for unit in units:
+        assert unit in recipe
+    assert "openbao-restore-drill.service" in recipe
+    assert "sha256sum /var/lib/vault-snapshots/openbao.snap" in recipe
+    assert recipe.index(units[0]) < recipe.index(units[1]) < recipe.index(units[2])
+
+
 def test_scratch_restore_preflight_is_read_only_and_targets_orion_projects():
     justfile = (Path(__file__).parents[2] / "justfile").read_text()
     recipe = justfile.split("discovery-docker-scratch-preflight:", 1)[1].split(

--- a/tests/discovery-esp-scratch-restore/test_recipe.py
+++ b/tests/discovery-esp-scratch-restore/test_recipe.py
@@ -118,9 +118,370 @@ def test_postgres_drill_is_full_cluster_isolated_and_value_free():
     assert "ssh-keyscan -p 2222" in recipe
     assert "SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE" in recipe
     assert "StrictHostKeyChecking=yes" in recipe
-    assert "ssh -n -p 2222" in recipe
+    assert "ssh -n" in recipe
     assert "SELECT datname" in recipe
     assert "pg_extension" in recipe
     assert "information_schema.tables" in recipe
     assert "SELECT *" not in recipe
     assert 'sudo tee "$evidence/result.txt"' in recipe
+
+
+def test_redis_drill_proves_empty_networkless_cold_start():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-redis-cold-start-drill:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "--network none" in recipe
+    assert "DBSIZE" in recipe
+    assert "for database in 0 1 2 3 4" in recipe
+    assert "dump.rdb" not in recipe
+    assert "redis-cli" in recipe
+
+
+def test_netbird_preflight_reads_pocketid_sqlite_without_values():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-netbird-state-preflight:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert '"$SQLITE3" -readonly' in recipe
+    assert "PRAGMA integrity_check" in recipe
+    assert "sqlite_master" in recipe
+    assert "SELECT *" not in recipe
+    assert "python3" not in recipe
+    assert "netbird-management" in recipe
+    assert "netbird-pocketid" in recipe
+
+
+def test_pocketid_repair_refuses_live_process_or_bad_database():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("repair-netbird-pocketid:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "pgrep" in recipe
+    assert "fuser" in recipe
+    assert "PRAGMA integrity_check" in recipe
+    assert "systemctl reset-failed" in recipe
+    assert "systemctl start docker-netbird-pocketid.service" in recipe
+    assert ".well-known/openid-configuration" in recipe
+    assert "DELETE FROM" not in recipe
+
+
+def test_pocketid_drill_uses_native_backup_and_network_isolation():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-pocketid-restore-drill:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert ".backup" in recipe
+    assert "ssh -n" in recipe
+    assert "--network none" in recipe
+    assert "--env-file" in recipe
+    assert "/app/pocket-id healthcheck" in recipe
+    assert 'sudo docker logs "$name"' in recipe
+    assert "DELETE FROM kv WHERE key='application_lock'" in recipe
+    assert "name LIKE 'francis_%'" in recipe
+    assert "PRAGMA foreign_keys=OFF" in recipe
+    assert "DROP VIEW IF EXISTS" in recipe
+    assert "DROP TABLE IF EXISTS" in recipe
+    assert "SELECT count(*) FROM users" in recipe
+    assert "SELECT *" not in recipe
+
+
+def test_netbird_management_drill_uses_internal_network_and_restored_db():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-netbird-management-restore-drill:", 1)[
+        1
+    ].split("\n# ", 1)[0]
+
+    assert "docker network create --internal" in recipe
+    assert "postgres-all.sql.gz" in recipe
+    assert "netbirdio/management:0.74.3" in recipe
+    assert "--network-alias postgres" in recipe
+    assert "/run/netbird-management/management.json" in recipe
+    assert "NETBIRD_STORE_ENGINE_POSTGRES_DSN" in recipe
+    assert "docker port" in recipe
+    assert "for table in peers groups users" in recipe
+    assert "SELECT count(*) FROM $table" in recipe
+    assert "SELECT *" not in recipe
+
+
+def test_swag_drill_copies_config_and_validates_without_network_or_ports():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-swag-restore-drill:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "sudo rsync -aHAXx --numeric-ids" in recipe
+    assert "--network none" in recipe
+    assert "--entrypoint /usr/sbin/nginx" in recipe
+    assert "nginx -t" in recipe
+    assert "x509 -checkend" in recipe
+    assert "pkey -in" in recipe
+    assert "for route in harbor netbird pocket-id grafana" in recipe
+    assert "docker port" not in recipe
+
+
+def test_harbor_preflight_binds_vault_state_and_orion_capacity():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-harbor-restore-preflight:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "/home/erik/vault/harbor" in recipe
+    assert "d026033d-158d-49ca-9ff9-dd2d5c8a21dc" in recipe
+    assert "/projects/recovery/discovery-esp/harbor" in recipe
+    assert "findmnt -bnro AVAIL -T /projects" in recipe
+    assert "docker ps -a --format json" in recipe
+    assert "rsync" not in recipe
+
+
+def test_harbor_seed_uses_root_rsync_and_pinned_host_key():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-harbor-restore-seed:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "just discovery-harbor-restore-preflight" in recipe
+    assert "SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE" in recipe
+    assert "sudo rsync -aHAXx --numeric-ids" in recipe
+    assert "--rsync-path='sudo rsync'" in recipe
+    assert "/home/erik/vault/harbor/" in recipe
+    assert "root=/projects/recovery/discovery-esp/harbor" in recipe
+    assert "state=$root/state" in recipe
+    assert ".harbor-installer/harbor/" in recipe
+
+
+def test_harbor_finalize_always_restarts_and_proves_zero_drift():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-harbor-restore-finalize:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "systemctl stop harbor.service" in recipe
+    assert "trap resume EXIT" in recipe
+    assert "sudo rsync -aHAXxni --numeric-ids --delete" in recipe
+    assert 'test -z "$drift"' in recipe
+    assert "systemctl start harbor.service" in recipe
+    assert "/api/v2.0/health" in recipe
+
+
+def test_harbor_inspect_exposes_topology_without_environment():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-harbor-restore-inspect:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "docker compose -f" in recipe
+    assert "config --format json" in recipe
+    assert ".services | to_entries[]" in recipe
+    assert "source" in recipe
+    assert "published" in recipe
+    assert ".environment" not in recipe
+
+
+def test_harbor_drill_rebuilds_scratch_and_exercises_registry():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-harbor-restore-drill:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "./prepare" in recipe
+    assert "127.0.0.1:18085" in recipe
+    assert "0.0.0.0:18085" in recipe
+    assert "COMPOSE_PROJECT_NAME=discovery-harbor-drill" in recipe
+    assert "/^    logging:$/" in recipe
+    assert "podman login" in recipe
+    assert "podman pull" in recipe
+    assert "podman push" in recipe
+    assert "podman rmi" in recipe
+    assert "discovery-esp-drill-" in recipe
+    assert "/api/v2.0/system/gc/schedule" in recipe
+    assert "compose down" in recipe
+
+
+def test_haos_preflight_binds_live_disk_vault_and_orion_capacity():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-haos-restore-preflight:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "virsh domblklist haos" in recipe
+    assert "virsh domstate haos" in recipe
+    assert "d026033d-158d-49ca-9ff9-dd2d5c8a21dc" in recipe
+    assert "qemu-img" in recipe
+    assert "findmnt -bnro AVAIL -T /projects" in recipe
+    assert "rsync" not in recipe
+
+
+def test_haos_seed_uses_pinned_host_key_and_root_rsync():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-haos-restore-seed:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "just discovery-haos-restore-preflight" in recipe
+    assert "SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE" in recipe
+    assert "--rsync-path='sudo rsync'" in recipe
+    assert "/srv/vms/haos_ova-17.1.qcow2" in recipe
+    assert "root=/projects/recovery/discovery-esp/haos" in recipe
+
+
+def test_haos_finalize_always_restarts_and_checks_clone():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-haos-restore-finalize:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "virsh shutdown haos" in recipe
+    assert "trap resume EXIT" in recipe
+    assert "virsh start haos" in recipe
+    assert "rsync -aHAXS --inplace" in recipe
+    assert "rsync -aHAXSni" in recipe
+    assert '"$QEMU_IMG" check' in recipe
+    assert "192.168.10.115:8123" in recipe
+
+
+def test_haos_result_checks_clone_and_production_without_mutation():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-haos-restore-result:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert '"$QEMU_IMG" check' in recipe
+    assert "virsh domstate haos" in recipe
+    assert "192.168.10.115:8123" in recipe
+    assert "virsh start" not in recipe
+    assert "rsync" not in recipe
+
+
+def test_haos_boot_drill_is_networkless_snapshot_and_pid_scoped():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-haos-boot-drill:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "-nic none" in recipe
+    assert "-snapshot" in recipe
+    assert "edk2-x86_64-code.fd" in recipe
+    assert "edk2-i386-vars.fd" in recipe
+    assert "virtio-scsi-pci" in recipe
+    assert "Home Assistant Operating System" in recipe
+    assert 'kill "$(cat "$pidfile")"' in recipe
+
+
+def test_home_preflight_finds_required_restore_classes_and_capacity():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-home-restore-preflight:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert ".config/sops/age/keys.txt" in recipe
+    assert "/etc/ssh/ssh_host_ed25519_key" in recipe
+    assert "servarr" in recipe
+    assert "swag" in recipe
+    assert "pocket-id" in recipe
+    assert "-size +1G" in recipe
+    assert "findmnt -bnro AVAIL -T /bulk" in recipe
+    assert "restic" not in recipe
+
+
+def test_home_backup_is_encrypted_and_selectively_verified():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("backup-discovery-home-kepler:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "RESTIC_PASSWORD_FILE" in recipe
+    assert "sftp:erik@" in recipe
+    assert "/bulk/backups/discovery-esp-home" in recipe
+    assert "tar --one-file-system" in recipe
+    assert ".config/sops/age/keys.txt" in recipe
+    assert "etc/ssh/ssh_host_ed25519_key" in recipe
+    assert ".env.sops" in recipe
+    assert "priv-fullchain-bundle.pem" in recipe
+    assert "pocket-id.db" in recipe
+    assert "model.safetensors" in recipe
+    assert "restic dump" in recipe
+    assert "sha256sum" in recipe
+
+
+def test_adguard_restore_preflight_reads_live_mounts_without_environment():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-adguard-restore-preflight:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "docker inspect adguard" in recipe
+    assert 'Destination == "/opt/adguardhome/work"' in recipe
+    assert 'Destination == "/opt/adguardhome/conf"' in recipe
+    assert "adguard/adguardhome:v0.108.0-b.83@sha256:" in recipe
+    assert "findmnt -bnro AVAIL -T /projects" in recipe
+    assert ".Config.Env" not in recipe
+    assert "rsync" not in recipe
+
+
+def test_adguard_seed_copies_live_mounts_with_pinned_host_key():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-adguard-restore-seed:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "just discovery-adguard-restore-preflight" in recipe
+    assert "SHA256:Y+aJii1TUFtxSY7+LGT0hVBzEatKss/wDHBLFFXk0HE" in recipe
+    assert "/var/lib/docker/volumes/discovery-adguard-work/_data/" in recipe
+    assert "/home/erik/servarr/machines/discovery/runtime/adguard/" in recipe
+    assert "--rsync-path='sudo rsync'" in recipe
+    assert "root=/projects/recovery/discovery-esp/adguard" in recipe
+    assert 'chmod 0644 "$known_hosts"' in recipe
+    assert 'install -d -m 0700 "$root/work" "$root/conf"' in recipe
+    assert "test ! -e" not in recipe
+    assert "rm -rf" not in recipe
+
+
+def test_adguard_finalize_bounds_dns_downtime_and_restores_exact_containers():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-adguard-restore-finalize:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert ".gsd/evidence/p3-dns/runs/20260715T235959Z-d5cf3b5979d8/result.json" in recipe
+    assert ".status == \"passed\"" in recipe
+    assert "for transport in +notcp +tcp" in recipe
+    assert 'dig "$transport"' in recipe
+    assert "docker inspect adguard adguard-exporter" in recipe
+    assert "docker stop --time 120" in recipe
+    assert "trap restart EXIT INT TERM" in recipe
+    assert "/var/lib/docker/volumes/discovery-adguard-work/_data/" in recipe
+    assert "/home/erik/servarr/machines/discovery/runtime/adguard/" in recipe
+    assert "--dry-run --itemize-changes" in recipe
+    assert "docker start" in recipe
+    assert "dns_ready=false" in recipe
+    assert "dns_ready=true" in recipe
+    assert 'test "$dns_ready" = true' in recipe
+    assert "docker rm" not in recipe
+    assert "docker volume" not in recipe
+
+
+def test_adguard_drill_uses_copied_state_and_loopback_dns_only():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-adguard-restore-drill:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "adguard/adguardhome:v0.108.0-b.83@sha256:" in recipe
+    assert "/projects/recovery/discovery-esp/adguard/work" in recipe
+    assert 'cp -a --reflink=auto "$source_work/." "$work/"' in recipe
+    assert "127.0.0.1:15353:53/tcp" in recipe
+    assert "127.0.0.1:15353:53/udp" in recipe
+    assert "127.0.0.1:18090:80/tcp" in recipe
+    assert "for transport in +notcp +tcp" in recipe
+    assert "restore-drill.homelab.pastelariadev.com" in recipe
+    assert "restore-drill.doubleclick.net" in recipe
+    assert "cloudflare.com" in recipe
+    assert "flags:.* ad" in recipe
+    assert "--network host" not in recipe
+    assert "192.168.10.210:53" not in recipe
+    assert "docker volume" not in recipe

--- a/tests/discovery-esp-scratch-restore/test_recipe.py
+++ b/tests/discovery-esp-scratch-restore/test_recipe.py
@@ -17,6 +17,20 @@ def test_live_preflight_does_not_pin_volatile_device_names():
     assert "/dev/sdc" not in recipe
 
 
+def test_docker_finalize_does_not_pin_volatile_device_names():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("discovery-docker-mirror-finalize:", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert "ata-KINGSTON_SA400S37480G_AA000000000000000105-part2" in recipe
+    assert "ata-ST4000DM004-2CV104_ZTT25R4M-part1" in recipe
+    assert 'findmnt -nro SOURCE -T "$source"' in recipe
+    assert "/dev/sda" not in recipe
+    assert "/dev/sdb" not in recipe
+    assert "/dev/sdc" not in recipe
+
+
 def test_scratch_restore_preflight_is_read_only_and_targets_orion_projects():
     justfile = (Path(__file__).parents[2] / "justfile").read_text()
     recipe = justfile.split("discovery-docker-scratch-preflight:", 1)[1].split(


### PR DESCRIPTION
## Summary
- add guarded Discovery identity, home, OpenBao, Docker, and substrate restore recipes
- repair Hermes wiki bootstrap and Telstar clone/state recovery paths
- add post-install acceptance and recovery contracts

## Verification
- `pytest -q tests/discovery-esp-scratch-restore/test_recipe.py`
- `just lint && just fmt-check`
- `just dry discovery`

GPU acceptance remains pending physical P2000 repair.