### PR TITLE
Refresh desktop inputs and diagnostics

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -123,11 +123,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1784758749,
-        "narHash": "sha256-rNwvRrqedbd6jspIckIb5brLrAWmdOMqhqxLORTVx8Q=",
+        "lastModified": 1784948311,
+        "narHash": "sha256-zXmyx6HuIjH0RQPV4VjVAXQttLyLDk55x9c3NmDke8c=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "1343337ba7dbc8b72bbe4d0f7084e95acc46570c",
+        "rev": "0d3cd1d6260b6f0ed232224c274c565407446fa1",
         "type": "github"
       },
       "original": {
@@ -149,12 +149,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1784301866,
-        "narHash": "sha256-12A2Cd8W0rE8S2JN9ndnDCaeBzjHJR+HP0+oG5HIC+c=",
-        "rev": "4695421aa97fd54bcc233b74de966123158c4cb6",
-        "revCount": 15,
+        "lastModified": 1784988346,
+        "narHash": "sha256-NeDs2kA1WH5Tc2ZZAM2dSl7LduznXntxplmP7uih8Bg=",
+        "rev": "6f3a724c14d01f55a6cb5d9c39adbb6457e2e7b1",
+        "revCount": 19,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/ErikBPF/codex-flake/0.2.15%2Brev-4695421aa97fd54bcc233b74de966123158c4cb6/019f70af-5be6-74f0-867f-7129234afdc2/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/ErikBPF/codex-flake/0.2.19%2Brev-6f3a724c14d01f55a6cb5d9c39adbb6457e2e7b1/019f999a-2a8e-78e0-8cb7-248052419d1a/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -170,11 +170,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1781627888,
-        "narHash": "sha256-5yHuAh9k7rT7rtf3uRaXkiUyYvQE9oaCgzhprLm2mr8=",
+        "lastModified": 1785116464,
+        "narHash": "sha256-O5bnHIzOkp2SQl0eCqKIqKzjgy2u0GXirTKSUdwER4Q=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "6d3087eedff75a715b40c0e124ba15d2dd7bec28",
+        "rev": "4f4179edae9a9dd31339284c8334072e3a110528",
         "type": "github"
       },
       "original": {
@@ -426,16 +426,16 @@
     "hermes-agent-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1783480268,
-        "narHash": "sha256-RieWkLWEn21aamFvQTTnJwwQl00JJGgp3LvY3D3G3jQ=",
+        "lastModified": 1784572521,
+        "narHash": "sha256-QJEiBOLAVGeYBym4EUtnDgeIyJyDQWgmat70/yujiz4=",
         "owner": "NousResearch",
         "repo": "hermes-agent",
-        "rev": "9de9c25f620ff7f1ce0fd5457d596052d5159596",
+        "rev": "3ef6bbd201263d354fd83ec55b3c306ded2eb72a",
         "type": "github"
       },
       "original": {
         "owner": "NousResearch",
-        "ref": "v2026.7.7.2",
+        "ref": "v2026.7.20",
         "repo": "hermes-agent",
         "type": "github"
       }
@@ -458,12 +458,12 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1784645614,
-        "narHash": "sha256-VFkXvIb4uGetktM71hFrE2U/E7E26ym/+XRXQZNnQWY=",
-        "rev": "08af6ccabf7d3dbd5a0f00aa941f6e60411e4872",
-        "revCount": 44,
+        "lastModified": 1784988485,
+        "narHash": "sha256-dk04XexFa3+t1i9EZLKZC0iQH1Mjg/cHizZ/LXNH9k0=",
+        "rev": "f615ef42916c06cb02396d38e68fcc5a3f36c9f4",
+        "revCount": 49,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/ErikBPF/hermes-flake/0.2.44%2Brev-08af6ccabf7d3dbd5a0f00aa941f6e60411e4872/019f852f-37de-79a1-b8cc-665590e1e824/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/ErikBPF/hermes-flake/0.2.49%2Brev-f615ef42916c06cb02396d38e68fcc5a3f36c9f4/019f999e-77e3-7e51-b43c-b90b3cb5a8cf/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784725727,
-        "narHash": "sha256-J5+C9wsO0lhDyUalQzfplDbRjyHDYeEH5+9sdyXtwa8=",
+        "lastModified": 1784913159,
+        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "041a999e8c1c5b731913855909e68d30ca69b8e0",
+        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
         "type": "github"
       },
       "original": {
@@ -567,11 +567,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1784738137,
-        "narHash": "sha256-PLev9CsX56NNuOQHjtPsLo0BQGtTI+4TjRO1MQ/Q3aY=",
+        "lastModified": 1785081751,
+        "narHash": "sha256-gbtT0xEHzi3PKzXHbfLHSznDhjXsZZY+EQ7Kgjx0JMI=",
         "ref": "refs/heads/main",
-        "rev": "7d2ea270704c265dd100a7898e6186e49c6741a7",
-        "revCount": 7640,
+        "rev": "d8dc50309c551cfa44fee70744397311b8b7c5fc",
+        "revCount": 7650,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/hyprwm/Hyprland"
@@ -836,11 +836,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784705208,
-        "narHash": "sha256-G1JLSGuSf8G2yZUxwLAKH6buVqoTWPbfpiVLzSNq6ak=",
+        "lastModified": 1784963415,
+        "narHash": "sha256-FycEkL1vvoKEuTzkW3Hz9kQeyqK1+TV7mLc3/rus3w4=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "cf9383788741bdabcb13f5c323a978fd63e681e8",
+        "rev": "be17a1eeb43b5d80028bb4e217234298e663738a",
         "type": "github"
       },
       "original": {
@@ -918,11 +918,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784440659,
-        "narHash": "sha256-Q5kNLlWngt7TaIIZoxDKWMHjiSaNRVqr70FqWCRRfr4=",
+        "lastModified": 1785046085,
+        "narHash": "sha256-UiK+mmZJuLWQVhJ5b2wDzogIYWAesyRm6LA3h3Ulh3Y=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb",
+        "rev": "11665045df8b9938ef811a3bfdc65cffb02b4b70",
         "type": "github"
       },
       "original": {
@@ -938,11 +938,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784715123,
-        "narHash": "sha256-84rMK/x9fY83wjeI6GpGAYvmcsyDqffJqJSxCe3Ta9E=",
+        "lastModified": 1785036898,
+        "narHash": "sha256-W4TS2Tln72tBqyzpnLluIr0j5lSY3lDbg4qO9XA0SgM=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "c4c2a4e9060b8ca156a40b19729fa3f6ee4889fc",
+        "rev": "96d3a5d6e8e57d752efc0376af5b812290b4bede",
         "type": "github"
       },
       "original": {
@@ -971,11 +971,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784555310,
-        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
+        "lastModified": 1784783405,
+        "narHash": "sha256-4IHyyLgLBdKefkljdKod4IMn023pQiDXAWJA187cmdY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
+        "rev": "7525d999cd850b9a488817abc89c75dc733acf17",
         "type": "github"
       },
       "original": {
@@ -1063,11 +1063,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1784497964,
-        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {
@@ -1102,11 +1102,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1784057377,
-        "narHash": "sha256-yycNej5//EsRbV10moBoh+/63vXEwZD1ZFEiRm6C9rQ=",
+        "lastModified": 1785001306,
+        "narHash": "sha256-xWqmquUtqKXLeDZ1oQUO+rV4sjA9TShIJhLL8M5Bozo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "07180a087e4a00720dc0731cbcd8dec796974381",
+        "rev": "48409beb41e8e28b64e8160ca82d8a93fb628963",
         "type": "github"
       },
       "original": {
@@ -1174,12 +1174,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1784647285,
-        "narHash": "sha256-im4JnD5WL7026gadycNDZol+xb2rKdV4WJSxWbCofag=",
-        "rev": "cdd2182636e5465560971a9e22e29d07fa4150a5",
-        "revCount": 13,
+        "lastModified": 1784988402,
+        "narHash": "sha256-+QhhM95D8H8qfDGY+AIHYyOXvQ70QNyvoMVi0avu4OI=",
+        "rev": "b3ffa5b74566eb6b33be7f205024359b254b21df",
+        "revCount": 16,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/ErikBPF/opencode-flake/0.1.13%2Brev-cdd2182636e5465560971a9e22e29d07fa4150a5/019f8548-bd16-7870-8489-c9911d38a1b4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/ErikBPF/opencode-flake/0.1.16%2Brev-b3ffa5b74566eb6b33be7f205024359b254b21df/019f999c-174e-71f0-b5c9-ae53caef0b26/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -1281,11 +1281,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784600537,
-        "narHash": "sha256-4i2GzlclQ+SEYlcEZs0kFNI8iBk+sbQlVUtMiiogvck=",
+        "lastModified": 1784799776,
+        "narHash": "sha256-6AM0doj8hSNav9qkX4dOHOp1LSjegdQ+VmzDz9MnWAs=",
         "ref": "refs/heads/master",
-        "rev": "e649d247498512464457aefcd05b73038c4e65a1",
-        "revCount": 832,
+        "rev": "10b439fc6e3fd65c15fe1c486271b31da05ed023",
+        "revCount": 833,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },

--- a/justfile
+++ b/justfile
@@ -6918,6 +6918,110 @@ diagnose-discovery-gpu:
         grep -Ei 'nvidia|nouveau|NVRM|BAR|IOMMU|firmware' | tail -120 || true
     REMOTE
 
+# Run one bounded 4K60 NVENC load and sample fan/thermal telemetry.
+test-discovery-gpu-load duration="60":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    duration={{duration}}
+    test "$duration" -ge 5
+    test "$duration" -le 900
+    ssh -p 2222 erik@{{ip_discovery}} "DURATION=$duration bash -s" <<'REMOTE'
+      set -euo pipefail
+      duration=$DURATION
+      query() {
+        nvidia-smi --query-gpu=timestamp,fan.speed,temperature.gpu,power.draw,utilization.gpu,utilization.encoder \
+          --format=csv,noheader
+      }
+      image=lscr.io/linuxserver/jellyfin:10.11.11@sha256:bb8d372e35d5c4a6cb61d830a06f5b5846528315b97cf5d38b80eea1e430efa7
+      sudo docker inspect -f '{{"{{"}}.State.Health.Status{{"}}"}}' jellyfin | grep -Fx healthy
+      sudo docker image inspect "$image" >/dev/null
+      query
+      timeout "$((duration + 20))" sudo docker run --rm --pull never \
+        --network none --device nvidia.com/gpu=all \
+        --entrypoint /usr/lib/jellyfin-ffmpeg/ffmpeg "$image" \
+        -hide_banner -loglevel error -re \
+        -f lavfi -i testsrc2=size=3840x2160:rate=60 -t "$duration" \
+        -c:v h264_nvenc -preset p1 -f null - &
+      load_pid=$!
+      for _ in $(seq 1 "$((duration / 2 + 2))"); do
+        query
+        kill -0 "$load_pid" 2>/dev/null || break
+        sleep 2
+      done
+      wait "$load_pid"
+      query
+    REMOTE
+
+# Temporarily request a fixed GPU fan speed through a private headless X server.
+test-discovery-gpu-fan percent="80" duration="10":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    percent={{percent}}
+    duration={{duration}}
+    test "$percent" -ge 30
+    test "$percent" -le 100
+    test "$duration" -ge 5
+    test "$duration" -le 30
+    xorg=$(nix eval --raw .#nixosConfigurations.discovery.pkgs.xorg.xorgserver.outPath)
+    settings=$(nix eval --raw .#nixosConfigurations.discovery.config.hardware.nvidia.package.settings.outPath)
+    driver=$(nix eval --raw .#nixosConfigurations.discovery.config.hardware.nvidia.package.bin.outPath)
+    nix-store --realise "$xorg" "$settings" "$driver" >/dev/null
+    nix copy --to ssh-ng://erik@{{ip_discovery}}:2222 "$xorg" "$settings" "$driver"
+    ssh -p 2222 erik@{{ip_discovery}} \
+      "sudo bash -s -- $xorg $settings $driver $percent $duration" <<'REMOTE'
+      set -euo pipefail
+      xorg=$1
+      settings=$2
+      driver=$3
+      percent=$4
+      duration=$5
+      work=$(mktemp -d /run/discovery-gpu-fan-test.XXXXXX)
+      printf '%s\n' \
+        'Section "Files"' \
+        "  ModulePath \"$driver/lib/xorg/modules\"" \
+        "  ModulePath \"$xorg/lib/xorg/modules\"" \
+        'EndSection' \
+        'Section "Device"' \
+        '  Identifier "GPU0"' \
+        '  Driver "nvidia"' \
+        '  BusID "PCI:1:0:0"' \
+        '  Option "Coolbits" "4"' \
+        '  Option "AllowEmptyInitialConfiguration" "True"' \
+        'EndSection' \
+        'Section "Screen"' \
+        '  Identifier "Screen0"' \
+        '  Device "GPU0"' \
+        'EndSection' >"$work/xorg.conf"
+      "$xorg/bin/Xorg" :99 -config "$work/xorg.conf" -noreset -nolisten tcp \
+        -logfile "$work/Xorg.log" >"$work/stdout.log" 2>&1 &
+      xpid=$!
+      cleanup() {
+        "$settings/bin/nvidia-settings" -c :99 \
+          -a '[gpu:0]/GPUFanControlState=0' || true
+        kill "$xpid" 2>/dev/null || true
+        wait "$xpid" 2>/dev/null || true
+      }
+      trap cleanup EXIT
+      for _ in $(seq 1 10); do
+        "$settings/bin/nvidia-settings" -c :99 -q gpus >/dev/null 2>&1 && break
+        kill -0 "$xpid" 2>/dev/null || {
+          cat "$work/Xorg.log"
+          exit 1
+        }
+        sleep 1
+      done
+      "$settings/bin/nvidia-settings" -c :99 -q gpus >/dev/null
+      nvidia-smi --query-gpu=fan.speed,temperature.gpu,power.draw --format=csv,noheader
+      "$settings/bin/nvidia-settings" -c :99 \
+        -a '[gpu:0]/GPUFanControlState=1' \
+        -a "[fan:0]/GPUTargetFanSpeed=$percent"
+      sleep "$duration"
+      "$settings/bin/nvidia-settings" -c :99 \
+        -q '[fan:0]/GPUCurrentFanSpeed' \
+        -q '[fan:0]/GPUTargetFanSpeed'
+      nvidia-smi --query-gpu=fan.speed,temperature.gpu,power.draw --format=csv,noheader
+    REMOTE
+
 # Read-only post-install acceptance gate. Run only after dependency-ordered
 # restoration has completed; it does not start or repair any service.
 verify-discovery-esp:

--- a/modules/dev/herdr.nix
+++ b/modules/dev/herdr.nix
@@ -78,44 +78,51 @@
 
       # One launcher per agent. `type = "pane"` spawns the CLI in a fresh
       # pane; herdr's process-name + output heuristics then track its state.
-      keys.command = [
-        {
-          key = "prefix+alt+c";
-          type = "pane";
-          command = "claude";
-          description = "launch Claude Code";
-        }
-        {
-          key = "prefix+alt+x";
-          type = "pane";
-          command = "codex";
-          description = "launch Codex";
-        }
-        {
-          key = "prefix+alt+o";
-          type = "pane";
-          command = "opencode";
-          description = "launch opencode";
-        }
-        {
-          key = "prefix+alt+h";
-          type = "pane";
-          command = "hermes";
-          description = "launch Hermes Agent (local CLI → Discovery API)";
-        }
-        {
-          key = "prefix+t";
-          type = "plugin_action";
-          command = "herdr-navigator.open";
-          description = "jump to workspace, project, session, or agent";
-        }
-        {
-          key = "prefix+shift+p";
-          type = "plugin_action";
-          command = "cloudmanic.herdr-plus.projects";
-          description = "open project template";
-        }
-      ];
+      keys = {
+        focus_pane_left = ["prefix+h" "alt+left"];
+        focus_pane_right = ["prefix+l" "alt+right"];
+        focus_pane_up = ["prefix+k" "alt+up"];
+        focus_pane_down = ["prefix+j" "alt+down"];
+
+        command = [
+          {
+            key = "prefix+alt+c";
+            type = "pane";
+            command = "claude";
+            description = "launch Claude Code";
+          }
+          {
+            key = "prefix+alt+x";
+            type = "pane";
+            command = "codex";
+            description = "launch Codex";
+          }
+          {
+            key = "prefix+alt+o";
+            type = "pane";
+            command = "opencode";
+            description = "launch opencode";
+          }
+          {
+            key = "prefix+alt+h";
+            type = "pane";
+            command = "hermes";
+            description = "launch Hermes Agent (local CLI → Discovery API)";
+          }
+          {
+            key = "prefix+t";
+            type = "plugin_action";
+            command = "herdr-navigator.open";
+            description = "jump to workspace, project, session, or agent";
+          }
+          {
+            key = "prefix+shift+p";
+            type = "plugin_action";
+            command = "cloudmanic.herdr-plus.projects";
+            description = "open project template";
+          }
+        ];
+      };
     };
   };
 }

--- a/tests/discovery-esp-scratch-restore/test_recipe.py
+++ b/tests/discovery-esp-scratch-restore/test_recipe.py
@@ -850,3 +850,44 @@ def test_telstar_state_inventory_is_value_free_and_read_only():
     assert "cat " not in recipe
     assert "cp " not in recipe
     assert "rm " not in recipe
+
+
+def test_discovery_gpu_load_is_bounded_and_reports_telemetry():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("test-discovery-gpu-load duration=", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert '"$duration" -ge 5' in recipe
+    assert '"$duration" -le 900' in recipe
+    assert "timeout" in recipe
+    assert "testsrc2=size=3840x2160:rate=60" in recipe
+    assert "h264_nvenc" in recipe
+    assert "--device nvidia.com/gpu=all" in recipe
+    assert "--network none" in recipe
+    assert "--pull never" in recipe
+    assert "utilization.encoder" in recipe
+    assert "fan.speed" in recipe
+    assert "temperature.gpu" in recipe
+    assert "docker volume rm" not in recipe
+
+
+def test_discovery_gpu_fan_test_is_bounded_and_restores_auto_control():
+    justfile = (Path(__file__).parents[2] / "justfile").read_text()
+    recipe = justfile.split("test-discovery-gpu-fan percent=", 1)[1].split(
+        "\n# ", 1
+    )[0]
+
+    assert '"$percent" -ge 30' in recipe
+    assert '"$percent" -le 100' in recipe
+    assert '"$duration" -le 30' in recipe
+    assert 'Option "Coolbits" "4"' in recipe
+    assert 'Option "AllowEmptyInitialConfiguration" "True"' in recipe
+    assert "GPUFanControlState=1" in recipe
+    assert "GPUTargetFanSpeed=$percent" in recipe
+    assert "GPUFanControlState=0" in recipe
+    assert "trap cleanup EXIT" in recipe
+    assert "-nolisten tcp" in recipe
+    assert "printf '%s\\n'" in recipe
+    assert "/etc/" not in recipe
+    assert "rm " not in recipe

--- a/tests/herdr-gemini/test_config.py
+++ b/tests/herdr-gemini/test_config.py
@@ -38,6 +38,15 @@ def test_navigation_uses_plus_projects_and_one_global_picker():
     assert 'dataplatform = "~/Documents/nstech/dataplatform"' in source
 
 
+def test_herdr_has_direct_directional_pane_navigation():
+    herdr = (ROOT / "modules/dev/herdr.nix").read_text()
+
+    assert 'focus_pane_left = ["prefix+h" "alt+left"];' in herdr
+    assert 'focus_pane_right = ["prefix+l" "alt+right"];' in herdr
+    assert 'focus_pane_up = ["prefix+k" "alt+up"];' in herdr
+    assert 'focus_pane_down = ["prefix+j" "alt+down"];' in herdr
+
+
 def test_gemini_imports_remote_session_profile_with_linger():
     gemini = (ROOT / "modules/hosts/orion/gemini.nix").read_text()
 


### PR DESCRIPTION
## Summary
- refresh pinned flake inputs
- add direct Herdr pane navigation
- add bounded Discovery GPU load and fan diagnostics

## Verification
- 58 targeted tests passed
- `just lint`
- `just fmt-check`
- `just docs-check`
- `just dry discovery`
- `just dry endeavour` evaluation passed; closure realization queued behind an existing Endeavour switch