### PR TITLE
fix(herdr): avoid plugin package collision

### DIFF
--- a/modules/dev/herdr-gemini.nix
+++ b/modules/dev/herdr-gemini.nix
@@ -159,7 +159,7 @@
       '';
     };
   in {
-    home.packages = [plus navigator repoBootstrap];
+    home.packages = [repoBootstrap pkgs.jq];
 
     xdg.configFile = {
       "herdr/plugins/config/cloudmanic.herdr-plus/projects/homelab.toml".source = toml.generate "herdr-plus-homelab.toml" (project {


### PR DESCRIPTION
Remove plugin derivations from `home.packages`; Home Manager already links them during activation. This avoids their conflicting root-level `herdr-plugin.toml` files.