### PR TITLE
fix(discovery): accept drift exit status

### DIFF
--- a/modules/services/homelab-iac-drift.nix
+++ b/modules/services/homelab-iac-drift.nix
@@ -125,6 +125,7 @@ _: {
 
         serviceConfig = {
           Type = "oneshot";
+          SuccessExitStatus = [2];
           User = cfg.user;
           WorkingDirectory = cfg.repoPath;
           # Load the repo's secrets into the environment, then plan all units.

--- a/tests/homelab-iac-drift/test_contract.py
+++ b/tests/homelab-iac-drift/test_contract.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_drift_exit_is_not_a_failed_unit():
+    module = (
+        Path(__file__).parents[2] / "modules/services/homelab-iac-drift.nix"
+    ).read_text()
+
+    assert 'SuccessExitStatus = [2];' in module


### PR DESCRIPTION
Treat drift-check exit 2 as a successful oneshot result. Exit 2 already sends the dedicated drift notification; only execution errors should trip the generic failed-unit alert.