### PR TITLE
fix(drift): refresh GitHub token at runtime

### DIFF
--- a/modules/hosts/discovery/_vault-agent.nix
+++ b/modules/hosts/discovery/_vault-agent.nix
@@ -70,6 +70,11 @@ in {
           perms = "0600"
         }
         template {
+          contents = "{{ with secret \"secret/data/home/github-app-management\" }}KINDLE_RELEASE_CLIENT_ID={{ .Data.data.KINDLE_RELEASE_CLIENT_ID }}\nKINDLE_RELEASE_CLIENT_SECRET={{ .Data.data.KINDLE_RELEASE_CLIENT_SECRET }}\nGITHUB_APP_MANAGEMENT_REFRESH_TOKEN={{ .Data.data.GITHUB_APP_MANAGEMENT_REFRESH_TOKEN }}\n{{ end }}"
+          destination = "/run/vault-agent/github-app-management.env"
+          perms = "0440"
+        }
+        template {
           contents = "DISCORD_WEBHOOK_INCIDENTS={{ with secret \"secret/data/shared/discord\" }}{{ .Data.data.incidents }}{{ end }}\nDISCORD_WEBHOOK_DEPLOYS={{ with secret \"secret/data/shared/discord\" }}{{ .Data.data.deploys }}{{ end }}\nSCRUTINY_NOTIFY_URLS={{ with secret \"secret/data/shared/discord\" }}{{ .Data.data.scrutiny }}{{ end }}\nWEBHOOK_GRAFANA_ALERTS_SECRET={{ with secret \"secret/data/shared/discord\" }}{{ .Data.data.argus_webhook_hmac }}{{ end }}\n"
           destination = "/run/vault-agent/discord.env"
           perms = "0440"

--- a/modules/services/homelab-iac-drift.nix
+++ b/modules/services/homelab-iac-drift.nix
@@ -40,6 +40,12 @@ _: {
         description = "Path to a file holding the Discord webhook URL for drift alerts (read at runtime; empty = log only).";
       };
 
+      githubAppManagementEnvFile = lib.mkOption {
+        type = lib.types.str;
+        default = "/run/vault-agent/github-app-management.env";
+        description = "Vault-rendered OAuth client and refresh token used to obtain an ephemeral GitHub App management token.";
+      };
+
       sopsAgeKeyFile = lib.mkOption {
         type = lib.types.str;
         default = "/home/${cfg.user}/.config/sops/age/keys.txt";
@@ -89,6 +95,7 @@ _: {
         after = [
           "network-online.target"
           "tailscaled.service"
+          "vault-agent.service"
         ];
         wants = ["network-online.target"];
 
@@ -102,6 +109,7 @@ _: {
           git
           openssh
           docker
+          openbao
           gnugrep
           gnused
           coreutils
@@ -171,7 +179,13 @@ _: {
               value="''${value%\'}"
               value="''${value#\'}"
               export "$key=$value"
-            done < <(${pkgs.sops}/bin/sops --input-type dotenv --output-type dotenv --decrypt .env.sops)
+            done < <(
+              ${pkgs.sops}/bin/sops --input-type dotenv --output-type dotenv --decrypt .env.sops
+              cat ${lib.escapeShellArg cfg.githubAppManagementEnvFile}
+            )
+            export BAO_ADDR=http://127.0.0.1:8200
+            export BAO_TOKEN="$(cat /run/vault-agent/token)"
+            export GITHUB_APP_MANAGEMENT_TOKEN="$(bin/refresh-github-app-token.sh)"
             exec bash bin/drift-check.sh
           '';
         };

--- a/tests/homelab-iac-drift/test_contract.py
+++ b/tests/homelab-iac-drift/test_contract.py
@@ -7,3 +7,12 @@ def test_drift_exit_is_not_a_failed_unit():
     ).read_text()
 
     assert 'SuccessExitStatus = [2];' in module
+
+
+def test_github_app_token_is_refreshed_at_runtime():
+    module = (
+        Path(__file__).parents[2] / "modules/services/homelab-iac-drift.nix"
+    ).read_text()
+
+    assert "githubAppManagementEnvFile" in module
+    assert "refresh-github-app-token.sh" in module


### PR DESCRIPTION
Render GitHub OAuth refresh inputs from Vault and refresh the short-lived management token before each Discovery drift plan.