### PR TITLE
fix(drift): invoke token refresh with bash

### DIFF
--- a/modules/services/homelab-iac-drift.nix
+++ b/modules/services/homelab-iac-drift.nix
@@ -185,7 +185,7 @@ _: {
             )
             export BAO_ADDR=http://127.0.0.1:8200
             export BAO_TOKEN="$(cat /run/vault-agent/token)"
-            export GITHUB_APP_MANAGEMENT_TOKEN="$(bin/refresh-github-app-token.sh)"
+            export GITHUB_APP_MANAGEMENT_TOKEN="$(bash bin/refresh-github-app-token.sh)"
             exec bash bin/drift-check.sh
           '';
         };

--- a/tests/homelab-iac-drift/test_contract.py
+++ b/tests/homelab-iac-drift/test_contract.py
@@ -16,3 +16,4 @@ def test_github_app_token_is_refreshed_at_runtime():
 
     assert "githubAppManagementEnvFile" in module
     assert "refresh-github-app-token.sh" in module
+    assert 'GITHUB_APP_MANAGEMENT_TOKEN="$(bash bin/refresh-github-app-token.sh)"' in module


### PR DESCRIPTION
The refresh script is non-executable in the homelab-iac checkout. Invoke it through bash so the scheduled unit can rotate credentials.