### PR TITLE
feat(desktop): install Buzz

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,6 +117,32 @@
         "type": "github"
       }
     },
+    "buzz-flake": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785278862,
+        "narHash": "sha256-YzLne2TGv4jcfDSsp47LYXxjTwOeM9CJh4eqexyIMIs=",
+        "owner": "ErikBPF",
+        "repo": "buzz-flake",
+        "rev": "0fa2b21b07853fcb3fdb3e27c90fb0d0758d2659",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ErikBPF",
+        "repo": "buzz-flake",
+        "type": "github"
+      }
+    },
     "claude-code-nix": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -1296,6 +1322,7 @@
     },
     "root": {
       "inputs": {
+        "buzz-flake": "buzz-flake",
         "claude-code-nix": "claude-code-nix",
         "codex-flake": "codex-flake",
         "deploy-rs": "deploy-rs",

--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,13 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    buzz-flake = {
+      url = "github:ErikBPF/buzz-flake";
+      inputs.flake-parts.follows = "flake-parts";
+      inputs.home-manager.follows = "home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     opencode-flake = {
       url = "https://flakehub.com/f/ErikBPF/opencode-flake/*";
       inputs.flake-parts.follows = "flake-parts";

--- a/modules/dev/buzz.nix
+++ b/modules/dev/buzz.nix
@@ -1,0 +1,6 @@
+{inputs, ...}: {
+  flake.modules.home.buzz = {
+    imports = [inputs.buzz-flake.homeManagerModules.withPackage];
+    programs.buzz.enable = true;
+  };
+}

--- a/modules/profiles/desktop.nix
+++ b/modules/profiles/desktop.nix
@@ -68,6 +68,7 @@ in {
       m.home.nvim
       m.home.claude-code
       m.home.codex
+      m.home.buzz
       m.home.opencode
       m.home.hermes-agent
       m.home.herdr

--- a/tests/buzz/test_wiring.py
+++ b/tests/buzz/test_wiring.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+
+
+def test_buzz_is_enabled_for_desktops():
+    module_path = ROOT / "modules/dev/buzz.nix"
+    assert module_path.exists()
+
+    flake = (ROOT / "flake.nix").read_text()
+    profile = (ROOT / "modules/profiles/desktop.nix").read_text()
+    module = module_path.read_text()
+
+    assert "buzz-flake" in flake
+    assert "m.home.buzz" in profile
+    assert "inputs.buzz-flake.homeManagerModules.withPackage" in module
+    assert "programs.buzz.enable = true" in module


### PR DESCRIPTION
## Summary
- consume `ErikBPF/buzz-flake`
- enable Buzz in the desktop Home Manager profile
- pin Buzz 0.5.0

## Verification
- `python -m pytest -q tests/buzz/test_wiring.py`
- `just lint`
- `just fmt-check`
- `just dry endeavour`