### PR TITLE
fix(kepler): start security stack at boot

### DIFF
--- a/modules/hosts/kepler/compose.nix
+++ b/modules/hosts/kepler/compose.nix
@@ -9,11 +9,12 @@ _: {
       stacks = [
         # Order matters: each unit waits for the previous via After=.
         # Qdrant in infra must precede docs-search. Other heavier stacks
-        # (knowledge, photos, cicd, security) remain manual until migrated off
+        # (knowledge, photos, cicd) remain manual until migrated off
         # the legacy TrueNAS deployment.
         "infra"
         "monitoring"
         "sync"
+        "security"
         "whisper-gpu"
         "qwen4b-gpu"
       ];

--- a/tests/kepler-compose/test_kepler_compose.py
+++ b/tests/kepler-compose/test_kepler_compose.py
@@ -8,4 +8,5 @@ MODULE = ROOT / "modules/hosts/kepler/compose.nix"
 def test_enabled_stacks_include_backup_and_exclude_empty_profile():
     text = MODULE.read_text()
     assert '"sync"' in text
+    assert '"security"' in text
     assert '"docs-search"' not in text


### PR DESCRIPTION
## Summary
- add the Kepler security compose stack to boot orchestration

## Validation
- focused pytest passed
- `just lint`
- `just fmt-check`
- `just dry kepler`