### PR TITLE
feat(kepler): expose Buzz over NetBird

### DIFF
--- a/modules/hosts/kepler/default.nix
+++ b/modules/hosts/kepler/default.nix
@@ -27,6 +27,7 @@ in {
       m.nixos.kepler-recovery-tooling
       m.nixos.kepler-k1-inventory-tooling
       m.nixos.kepler-k3s-cluster
+      m.nixos.netbird-client
       m.nixos.first-boot
       m.nixos.alloy
       m.nixos.alloy-containers
@@ -69,6 +70,7 @@ in {
     # k3s test cluster (microvm nodes). Stage 1: single cp-1 VM (plumbing proof).
     # ⚠ Brings up systemd-networkd — deploy supervised (see the module header).
     kepler.k3s.enable = true;
+    modules.networking.netbird-client.enable = true;
 
     home-manager.users.${config.username}.imports = [
       m.home.kepler-ssh

--- a/modules/hosts/kepler/networking.nix
+++ b/modules/hosts/kepler/networking.nix
@@ -35,6 +35,7 @@ _: {
     };
 
     networking.firewall.interfaces.tailscale0.allowedTCPPorts = [9187];
+    networking.firewall.interfaces.wt0.allowedTCPPorts = [3000];
 
     # Tailscale client — no subnet routing needed (not the gateway host)
     services.tailscale = {

--- a/tests/buzz/test_wiring.py
+++ b/tests/buzz/test_wiring.py
@@ -16,3 +16,12 @@ def test_buzz_is_enabled_for_desktops():
     assert "m.home.buzz" in profile
     assert "inputs.buzz-flake.homeManagerModules.withPackage" in module
     assert "programs.buzz.enable = true" in module
+
+
+def test_kepler_exposes_buzz_only_on_netbird():
+    host = (ROOT / "modules/hosts/kepler/default.nix").read_text()
+    networking = (ROOT / "modules/hosts/kepler/networking.nix").read_text()
+
+    assert "m.nixos.netbird-client" in host
+    assert "modules.networking.netbird-client.enable = true" in host
+    assert "networking.firewall.interfaces.wt0.allowedTCPPorts = [3000];" in networking


### PR DESCRIPTION
Enroll Kepler in the managed NetBird overlay and open Buzz relay port 3000 only on wt0. Includes host wiring contract coverage.