### PR TITLE
fix(netbird): rotate bootstrap key

### DIFF
--- a/modules/hosts/kepler/compose.nix
+++ b/modules/hosts/kepler/compose.nix
@@ -12,6 +12,7 @@ _: {
         # (knowledge, photos, cicd) remain manual until migrated off
         # the legacy TrueNAS deployment.
         "infra"
+        "buzz"
         "monitoring"
         "sync"
         "security"

--- a/secrets/sops/secrets.yaml
+++ b/secrets/sops/secrets.yaml
@@ -36,7 +36,7 @@ netbird:
     pocketid_encryption_key: ENC[AES256_GCM,data:tQ0c0HJ3Gg10+7vgNd/YkeCCXvWLYfbCg22o+GuPfqvq7dki+MGJzXFCeao5HxqAcMM0wNKSzzmCCQY=,iv:rGwlw4mBeKEiICtMdaoKncDhNdapbJgKMgkm/cI7FC4=,tag:B6uLEmE2mpgR88+ujtmDFQ==,type:str]
     postgres_dsn: ENC[AES256_GCM,data:6vAigFcCaxtoSysGubkKpgiNjBlFNcmbPBDVESFsgUPZ4BRPlZ/XTSxswUdHjp5OlpCtDLrpKhXPakv4FrQPgJ+bM+jZUrkWlCmt1cIuBrdeyfWcmq6+vQnwtuxRGH9IQtuKhYtnatiP9PLqtJvp84d/mGxR27u03AWGZ56JN8+HQBVv6yJgdaxtu1Zj,iv:Gy5RqCpIGVZ9/IGBks2yasMW6r6yqMkE1JbeVB5uoeI=,tag:t1233c5wpwEfCvm2KM4w7g==,type:str]
     datastore_enc_key: ENC[AES256_GCM,data:/mJ5Em32n63M/ZftTPocBWY4+5imQ+R0E99geXky7kNZE9jJjgf4ljgEbb4=,iv:a7DAK1rQSpRCR+upNUurSBDUb9Fuw/F5BgDpvwFvXbY=,tag:Q3rxt1k6KycHl2mo2dDZkA==,type:str]
-    setup_key: ENC[AES256_GCM,data:yEG1XFgUj5S3NXBM0bhzxYox7sL4EpyuCPro07FR5P0RQ+5c,iv:B/LUCu+RHPQbxHDDePfRdQKmLUuAM1Sd0vIEd2pENjY=,tag:UMFFaogTeMPPL9caf3JFaw==,type:str]
+    setup_key: ENC[AES256_GCM,data:uZ7ifppB70UW2GSL9w2YnYPZMTBnE0g4mbXTGMoo6OpuJPHn,iv:K3BZYdJ3fMNBtfOtWFonaLWtDGF+bsy5YOT7ROXwHtc=,tag:nTHzcrV1AnxKR8ZN3w9rwA==,type:str]
 dead-mans-switch:
     discord_webhook: ENC[AES256_GCM,data:+EK+P1QcSocqRirMt9AwTu+dGQ8cNtzET4iT97FI94QkJIowR4MGJaVZdlNQeeGnGpGlGa+OUW/lcpSp7OCxZSTZqAEsMVC1Nvehl6DIfMM4q7QDEjnZdAyTcTzQC4aMMNmZWDhnJWUkFY6IbDU4vzaoYLpzlkDprQ==,iv:6N8S51XCTQo2yG99BuYLnc7IQFQBS7lo2BMCUWC+eeM=,tag:EcC3LuKAmGgXQQ6Y/haMCw==,type:str]
 renovate:
@@ -82,7 +82,7 @@ sops:
             OUdlMa+ARM8szMeMyLiMtl5mG139H6ziZ30P0Y2GO0Ne1L2MdRWSqA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1rnmn0c3sezwc2y90n66t740se98huva8w4hehyc2xlv32f8pnfssqkqsqj
-    lastmodified: "2026-07-24T03:41:43Z"
-    mac: ENC[AES256_GCM,data:25SsUGorU4iBE+glGOaqcmMehjyXvdst3RjZ/xg/Vo6UHy6GF11hty9nXyq+htDAAD9VAt4CI5yqgTeDf8qUFIXIMBHhYv/TGdDJnZCUhF0syBRcuCN9mIb/mpBFzdVaNgOan7rqXAZbzePmBR6On3Ir4dBDw6aK343abXruYDU=,iv:mv0I9A+7+0W4OZMkGTPkDjKuO6rL7eCT1RG+y0+IFq8=,tag:NQxA+gFtrkveuUTWInC6Og==,type:str]
+    lastmodified: "2026-07-29T12:44:10Z"
+    mac: ENC[AES256_GCM,data:yng/jsiJltfgRZiZIbxA11LkfkiikV1Rqgh4pslptQYYD7iKCDyj40dcxCPeE0Y4GW+NOkXdV82WyGA/h5FrhQMEGd8UK0VMH9gqNcDWOpVSIyCqkjnSAJnHP9pIQnlWhIzJAJ//TvlTQNhYSPuwoK2ld/dq5O0By0jyibITpW0=,iv:owONlWY7f3mgrDqG/8utDanjaBzo+RU4tiX+r5YY6hg=,tag:mTaZu/auwiOXz/nCYWsdBg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.0

--- a/tests/buzz/test_wiring.py
+++ b/tests/buzz/test_wiring.py
@@ -21,7 +21,9 @@ def test_buzz_is_enabled_for_desktops():
 def test_kepler_exposes_buzz_only_on_netbird():
     host = (ROOT / "modules/hosts/kepler/default.nix").read_text()
     networking = (ROOT / "modules/hosts/kepler/networking.nix").read_text()
+    compose = (ROOT / "modules/hosts/kepler/compose.nix").read_text()
 
     assert "m.nixos.netbird-client" in host
     assert "modules.networking.netbird-client.enable = true" in host
     assert "networking.firewall.interfaces.wt0.allowedTCPPorts = [3000];" in networking
+    assert '"buzz"' in compose


### PR DESCRIPTION
Rotate the expired seven-day fleet enrollment key after creating its replacement through homelab-iac.