### PR TITLE
feat(buzz): project owner secret and metrics

### DIFF
--- a/justfile
+++ b/justfile
@@ -2919,6 +2919,25 @@ seed-netbird-pocketid-vault: seed-netbird-vault
 
 seed-netbird-controlplane-vault: seed-netbird-vault
 
+# Move the Buzz owner identity from Kepler's bootstrap SOPS file into OpenBao.
+# The value is streamed through stdin and never printed or placed in argv.
+seed-buzz-vault source="../servarr/machines/kepler/.env.sops":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    owner="$(sops --decrypt --input-type dotenv --output-type json \
+      --extract '["BUZZ_OWNER_PRIVATE_KEY"]' \
+      "{{source}}")"
+    token="$(sops --decrypt --extract '["vault_root_token"]' secrets/sops/secrets.yaml)"
+    jq -nc --arg owner "$owner" '{data:{OWNER_PRIVATE_KEY:$owner}}' |
+      ssh -p 2222 erik@{{ip_discovery}} \
+        "curl -fsS -o /dev/null -X POST \
+          -H 'X-Vault-Token: $token' \
+          -H 'Content-Type: application/json' \
+          --data-binary @- \
+          http://127.0.0.1:8200/v1/secret/data/home/buzz"
+    unset owner token
+    echo "buzz_vault=seeded"
+
 # Verify metadata and dotenv name without exposing the key.
 verify-netbird-pocketid-secret-render:
     #!/usr/bin/env bash

--- a/modules/hosts/discovery/_vault-agent.nix
+++ b/modules/hosts/discovery/_vault-agent.nix
@@ -210,6 +210,11 @@ in {
             command = ["${pkgs.coreutils}/bin/chgrp", "docker", "/run/vault-agent/kindle-dash.env"]
           }
         }
+        template {
+          contents = "{{ with secret \"secret/data/home/buzz\" }}{{ .Data.data.OWNER_PRIVATE_KEY }}{{ end }}\n"
+          destination = "/run/vault-agent/buzz-owner.key"
+          perms = "0440"
+        }
       ''}";
     };
   };

--- a/modules/hosts/kepler/default.nix
+++ b/modules/hosts/kepler/default.nix
@@ -19,6 +19,7 @@ in {
       m.nixos.systemd-boot-counting
       m.nixos.kepler-hardware
       m.nixos.kepler-networking
+      m.nixos.kepler-monitoring
       m.nixos.kepler-syncthing
       m.nixos.kepler-nas
       m.nixos.containers

--- a/modules/hosts/kepler/monitoring.nix
+++ b/modules/hosts/kepler/monitoring.nix
@@ -1,0 +1,15 @@
+_: {
+  flake.modules.nixos.kepler-monitoring = {
+    environment.etc."alloy/buzz.alloy".text = ''
+      prometheus.scrape "buzz_relay" {
+        targets = [{
+          "__address__" = "127.0.0.1:9102",
+          "job"         = "buzz-relay",
+          "host"        = "kepler",
+        }]
+        forward_to      = [prometheus.remote_write.prometheus.receiver]
+        scrape_interval = "30s"
+      }
+    '';
+  };
+}

--- a/tests/buzz/test_wiring.py
+++ b/tests/buzz/test_wiring.py
@@ -27,3 +27,25 @@ def test_kepler_exposes_buzz_only_on_netbird():
     assert "modules.networking.netbird-client.enable = true" in host
     assert "networking.firewall.interfaces.wt0.allowedTCPPorts = [3000];" in networking
     assert '"buzz"' in compose
+
+
+def test_kepler_scrapes_buzz_metrics_locally():
+    host = (ROOT / "modules/hosts/kepler/default.nix").read_text()
+    monitoring = (ROOT / "modules/hosts/kepler/monitoring.nix").read_text()
+
+    assert "m.nixos.kepler-monitoring" in host
+    assert 'prometheus.scrape "buzz_relay"' in monitoring
+    assert '"__address__" = "127.0.0.1:9102"' in monitoring
+    assert '"job"         = "buzz-relay"' in monitoring
+    assert '"host"        = "kepler"' in monitoring
+
+
+def test_buzz_owner_key_moves_to_openbao_runtime_projection():
+    agent = (ROOT / "modules/hosts/discovery/_vault-agent.nix").read_text()
+    recipes = (ROOT / "justfile").read_text()
+
+    assert 'secret/data/home/buzz' in agent
+    assert 'destination = "/run/vault-agent/buzz-owner.key"' in agent
+    assert "seed-buzz-vault:" in recipes
+    assert '["BUZZ_OWNER_PRIVATE_KEY"]' in recipes
+    assert "secret/data/home/buzz" in recipes


### PR DESCRIPTION
Render the Buzz owner key from OpenBao only on Discovery, add a safe seeding recipe, and scrape Kepler relay metrics over loopback with Alloy.