### PR TITLE
feat(tailscale): route NanoKVM

### DIFF
--- a/modules/hosts/discovery/networking.nix
+++ b/modules/hosts/discovery/networking.nix
@@ -92,7 +92,7 @@ in {
       # only runs at first connect, so it wouldn't update an already-up node.
       extraSetFlags = [
         # selfIp (.210) from fleet SSOT; .1 = UDM, .2 = swOS, .157 = NanoKVM.
-        "--advertise-routes=${selfIp}/32,192.168.10.1/32,192.168.10.2/32,192.168.10.157/32"
+        "--advertise-routes=${selfIp}/32,192.168.10.1/32,192.168.10.2/32,192.168.10.4/32"
       ];
     };
   };

--- a/modules/hosts/discovery/networking.nix
+++ b/modules/hosts/discovery/networking.nix
@@ -91,8 +91,8 @@ in {
       # activation, so changing the route takes effect on switch. extraUpFlags
       # only runs at first connect, so it wouldn't update an already-up node.
       extraSetFlags = [
-        # selfIp (.210) from fleet SSOT; .1 = UDM, .2 = swOS switch (not fleet hosts).
-        "--advertise-routes=${selfIp}/32,192.168.10.1/32,192.168.10.2/32"
+        # selfIp (.210) from fleet SSOT; .1 = UDM, .2 = swOS, .157 = NanoKVM.
+        "--advertise-routes=${selfIp}/32,192.168.10.1/32,192.168.10.2/32,192.168.10.157/32"
       ];
     };
   };

--- a/tests/nanokvm-route/test_route.py
+++ b/tests/nanokvm-route/test_route.py
@@ -8,4 +8,4 @@ def test_discovery_advertises_nanokvm_host_route():
     repo = pathlib.Path(__file__).resolve().parents[2]
     config = (repo / "modules/hosts/discovery/networking.nix").read_text()
 
-    assert "192.168.10.157/32" in config
+    assert "192.168.10.4/32" in config

--- a/tests/nanokvm-route/test_route.py
+++ b/tests/nanokvm-route/test_route.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Discovery advertises the narrow NanoKVM subnet route."""
+
+import pathlib
+
+
+def test_discovery_advertises_nanokvm_host_route():
+    repo = pathlib.Path(__file__).resolve().parents[2]
+    config = (repo / "modules/hosts/discovery/networking.nix").read_text()
+
+    assert "192.168.10.157/32" in config


### PR DESCRIPTION
Adds the NanoKVM reserved-address /32 route and contract test. The route is already deployed and verified.