### PR TITLE
fix(buzz): wire relay and remove seed path

### DIFF
--- a/justfile
+++ b/justfile
@@ -2919,25 +2919,6 @@ seed-netbird-pocketid-vault: seed-netbird-vault
 
 seed-netbird-controlplane-vault: seed-netbird-vault
 
-# Move the Buzz owner identity from Kepler's bootstrap SOPS file into OpenBao.
-# The value is streamed through stdin and never printed or placed in argv.
-seed-buzz-vault source="../servarr/machines/kepler/.env.sops":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    owner="$(sops --decrypt --input-type dotenv --output-type json \
-      --extract '["BUZZ_OWNER_PRIVATE_KEY"]' \
-      "{{source}}")"
-    token="$(sops --decrypt --extract '["vault_root_token"]' secrets/sops/secrets.yaml)"
-    jq -nc --arg owner "$owner" '{data:{OWNER_PRIVATE_KEY:$owner}}' |
-      ssh -p 2222 erik@{{ip_discovery}} \
-        "curl -fsS -o /dev/null -X POST \
-          -H 'X-Vault-Token: $token' \
-          -H 'Content-Type: application/json' \
-          --data-binary @- \
-          http://127.0.0.1:8200/v1/secret/data/home/buzz"
-    unset owner token
-    echo "buzz_vault=seeded"
-
 # Verify metadata and dotenv name without exposing the key.
 verify-netbird-pocketid-secret-render:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -2145,6 +2145,28 @@ pull-servarr target branch="main":
     ssh -p 2222 erik@"$IP" 'export XDG_RUNTIME_DIR=/run/user/$(id -u); systemctl --user status servarr-pull.service --no-pager -n15'
     echo ":: {{target}} now on origin/{{branch}}. Recreate changed stacks: just kick-stack {{target}} <stack>"
 
+# Repair only the Git checkout surface; leave untracked container runtime state alone.
+repair-servarr-checkout target:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP="$(just _host-ip {{target}})"
+    ssh -p 2222 erik@"$IP" 'sudo -n bash -s' <<'REMOTE'
+    set -euo pipefail
+    repo=/home/erik/servarr
+    test -d "$repo/.git"
+    while IFS= read -r -d '' relative; do
+      path="$repo/$relative"
+      test ! -e "$path" || chown --no-dereference erik:users "$path"
+      parent=$(dirname "$path")
+      while test "$parent" != "$repo"; do
+        chown --no-dereference erik:users "$parent"
+        parent=$(dirname "$parent")
+      done
+    done < <(git -c safe.directory="$repo" -C "$repo" ls-files -z)
+    chown -R erik:users "$repo/.git"
+    echo "servarr_checkout=ownership_repaired"
+    REMOTE
+
 # Verify a signed kindle-dash release and mirror its exact digest into the
 # project-scoped Harbor library using the root-only Vault Agent render.
 mirror-kindle version digest:

--- a/modules/dev/buzz.nix
+++ b/modules/dev/buzz.nix
@@ -2,5 +2,6 @@
   flake.modules.home.buzz = {
     imports = [inputs.buzz-flake.homeManagerModules.withPackage];
     programs.buzz.enable = true;
+    home.sessionVariables.BUZZ_RELAY_URL = "http://kepler.netbird.internal:3000";
   };
 }

--- a/tests/buzz/test_wiring.py
+++ b/tests/buzz/test_wiring.py
@@ -16,6 +16,7 @@ def test_buzz_is_enabled_for_desktops():
     assert "m.home.buzz" in profile
     assert "inputs.buzz-flake.homeManagerModules.withPackage" in module
     assert "programs.buzz.enable = true" in module
+    assert 'BUZZ_RELAY_URL = "http://kepler.netbird.internal:3000";' in module
 
 
 def test_kepler_exposes_buzz_only_on_netbird():
@@ -40,12 +41,11 @@ def test_kepler_scrapes_buzz_metrics_locally():
     assert '"host"        = "kepler"' in monitoring
 
 
-def test_buzz_owner_key_moves_to_openbao_runtime_projection():
+def test_buzz_owner_key_uses_openbao_runtime_projection():
     agent = (ROOT / "modules/hosts/discovery/_vault-agent.nix").read_text()
     recipes = (ROOT / "justfile").read_text()
 
     assert 'secret/data/home/buzz' in agent
     assert 'destination = "/run/vault-agent/buzz-owner.key"' in agent
-    assert "seed-buzz-vault:" in recipes
-    assert '["BUZZ_OWNER_PRIVATE_KEY"]' in recipes
-    assert "secret/data/home/buzz" in recipes
+    assert "seed-buzz-vault" not in recipes
+    assert "BUZZ_OWNER_PRIVATE_KEY" not in recipes

--- a/tests/servarr/test_checkout_repair.py
+++ b/tests/servarr/test_checkout_repair.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+JUSTFILE = Path(__file__).parents[2] / "justfile"
+
+
+def test_checkout_repair_excludes_untracked_runtime_state():
+    recipes = JUSTFILE.read_text()
+    start = recipes.index("repair-servarr-checkout target:")
+    block = recipes[start : recipes.index("\n\n", start)]
+
+    assert "git -c safe.directory=\"$repo\" -C \"$repo\" ls-files -z" in block
+    assert 'chown -R erik:users "$repo/.git"' in block
+    assert 'chown -R erik:users "$repo"' not in block


### PR DESCRIPTION
## Changes

- set desktop Buzz clients to `http://kepler.netbird.internal:3000`
- remove completed root-token owner migration recipe

## Validation

- Buzz wiring tests pass
- lint and fmt-check pass
- dry-builds pass for Endeavour, laptop, and Pathfinder
- `/review` and `/simplify` completed