### PR TITLE
fix(servarr): repair broken symlinks

### DIFF
--- a/justfile
+++ b/justfile
@@ -2156,7 +2156,7 @@ repair-servarr-checkout target:
     test -d "$repo/.git"
     while IFS= read -r -d '' relative; do
       path="$repo/$relative"
-      test ! -e "$path" || chown --no-dereference erik:users "$path"
+      [[ -e "$path" || -L "$path" ]] && chown --no-dereference erik:users "$path"
       parent=$(dirname "$path")
       while test "$parent" != "$repo"; do
         chown --no-dereference erik:users "$parent"

--- a/tests/servarr/test_checkout_repair.py
+++ b/tests/servarr/test_checkout_repair.py
@@ -10,5 +10,6 @@ def test_checkout_repair_excludes_untracked_runtime_state():
     block = recipes[start : recipes.index("\n\n", start)]
 
     assert "git -c safe.directory=\"$repo\" -C \"$repo\" ls-files -z" in block
+    assert '[[ -e "$path" || -L "$path" ]]' in block
     assert 'chown -R erik:users "$repo/.git"' in block
     assert 'chown -R erik:users "$repo"' not in block


### PR DESCRIPTION
Follow-up from the whole-implementation review.

- repair tracked symlinks even when their targets are absent
- keep untracked runtime state excluded
- add regression coverage

Validated: 5 targeted tests, lint, format, and recipe dry-run.