### PR TITLE
fix(kepler): allow UniFi SIEM syslog

### DIFF
--- a/modules/hosts/kepler/networking.nix
+++ b/modules/hosts/kepler/networking.nix
@@ -30,6 +30,7 @@ _: {
           111 # rpcbind UDP
           4000 # statd UDP
           4001 # lockd UDP
+          5514 # UniFi SIEM syslog
         ];
       };
     };

--- a/tests/wazuh-siem-live-verify/test_wazuh_siem_live_verify.py
+++ b/tests/wazuh-siem-live-verify/test_wazuh_siem_live_verify.py
@@ -2,6 +2,9 @@ from pathlib import Path
 
 
 JUSTFILE = (Path(__file__).parents[2] / "justfile").read_text()
+KEPLER_NETWORKING = (
+    Path(__file__).parents[2] / "modules/hosts/kepler/networking.nix"
+).read_text()
 
 
 def test_live_wazuh_verifier_is_bounded_and_value_safe():
@@ -13,3 +16,7 @@ def test_live_wazuh_verifier_is_bounded_and_value_safe():
     assert "wazuh_unifi_last_event_seconds" in recipe
     assert "metric=absent" in recipe
     assert "192.168.10.230:5514" in recipe
+
+
+def test_kepler_firewall_accepts_unifi_syslog():
+    assert "5514 # UniFi SIEM syslog" in KEPLER_NETWORKING


### PR DESCRIPTION
## Summary
- allow UDP 5514 through Kepler's host firewall
- lock the UniFi SIEM firewall contract with a focused test

## Verification
- pytest -q tests/wazuh-siem-live-verify/test_wazuh_siem_live_verify.py
- just lint
- just fmt-check
- just dry kepler
- just switch-kepler && just reboot-kepler
- live capture: 10 UniFi packets, Wazuh archive delta +108
- security stack healthy; Grafana active alerts: 0